### PR TITLE
Use a specific command name to Apache Camel (#65)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.0.12
 
+- Fix incompatibility with Java Extension pack and Spring Boot Extension pack
 
 ## 0.0.11
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export function activate(context: ExtensionContext) {
 	languageClient.onReady().then(() => {
 		item.text = 'Apache Camel Language Server started';
 		toggleItem(window.activeTextEditor, item);
-		commands.registerCommand('java.open.output', ()=>{
+		commands.registerCommand('apache.camel.open.output', ()=>{
 		languageClient.outputChannel.show(ViewColumn.Three);
 	});
 


### PR DESCRIPTION
to avoid conflict with Java Extension pack
by side effect, it is also fixing the Spring-boot dashboard whcih wasn't showing up.

and I don't know how to write the test :'(