### PR TITLE
Use service instead of before_install script for xfvb #102

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js: "8"
+services:
+  - xvfb
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - 'export PATH=./node_modules/.bin:$PATH'
   - 'npm install -g typescript'
 install:


### PR DESCRIPTION
by default on travis, dist has been upgraded from trusty to xenial, the
old way is not workign anymore

Signed-off-by: Aurélien Pupier <apupier@redhat.com>