### PR TITLE
Update to name approved by Red Hat legal department #119

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.0.17
 
+- Update to naming approved by Red Hat legal
+
 ## 0.0.16
 
 - Provide completion for Camel URIs on Camel-K Groovy files:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-apache-camel",
-  "displayName": "Language Support for Apache Camel",
+  "displayName": "Language Support for Apache Camel by Red Hat",
   "description": "Provides completion and documentation features for Apache Camel URI elements in XML DSL.",
   "license": "Apache-2.0",
   "version": "0.0.17",


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>