### PR TITLE
FUSETOOLS2-56 - Allow to use specific Camel Catalog version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 .scannerwork
 log-camel-lsp.out
 test-resources
+testFixture/.vscode/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ undefined/**
 CONTRIBUTING.md
 .vscode-test/**
 test-resources
+testFixture/**

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## 0.0.19
 
 - Fix commenting of xml lines and blocks
+- Preference to choose the version of the Camel Catalog used by the Language server
 
 ## 0.0.18
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,8 @@ When you add this extension to your installation of VS Code, the VS Code editor 
 
   ![Find References for XML DSL](./images/findReference.gif "Find References for XML DSL")
 
+It is possible to use a specific Camel Catalog version. This can be specified in **File -> Preferences -> Settings -> Apache Camel Tooling -> Camel catalog version**
+
 For detailed information about Apache Camel supported features, see the [Language Server GitHub page](https://github.com/camel-tooling/camel-language-server#features).
 
 ## Contact Us

--- a/package.json
+++ b/package.json
@@ -60,6 +60,16 @@
   ],
   "main": "./out/src/extension.js",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Apache Camel Tooling",
+      "properties": {
+        "camel.Camel catalog version": {
+          "type": "string",
+          "description": "Camel catalog version used to provide Apache Camel Language Support. Depending on the connection speed, it can take several minutes to have it applied."
+        }
+      }
+    },
     "languages": [
       {
         "id": "xml",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ var os = require('os');
 var storagePath;
 
 const LANGUAGE_CLIENT_ID = 'LANGUAGE_ID_APACHE_CAMEL';
+const SETTINGS_TOP_LEVEL_KEY_CAMEL = 'camel';
 
 export function activate(context: ExtensionContext) {
 	// Let's enable Javadoc symbols autocompletion, shamelessly copied from MIT licensed code at
@@ -82,8 +83,8 @@ export function activate(context: ExtensionContext) {
 }
 
 function getCamelSettings() {
-	const camelXMLConfig = workspace.getConfiguration('camel');
-	return { 'camel' : JSON.parse(JSON.stringify(camelXMLConfig))};
+	const camelXMLConfig = workspace.getConfiguration(SETTINGS_TOP_LEVEL_KEY_CAMEL);
+	return { [SETTINGS_TOP_LEVEL_KEY_CAMEL] : JSON.parse(JSON.stringify(camelXMLConfig))};
 }
 
 function toggleItem(editor: TextEditor, item) {

--- a/src/test/catalog.version.test.ts
+++ b/src/test/catalog.version.test.ts
@@ -1,0 +1,56 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import { getDocUri, activate } from './helper';
+
+const expect = chai.expect;
+
+describe('Should do completion in Camel URI using the Camel Catalog version specified in preference', () => {
+	const docUriXml = getDocUri('test-catalog-version.xml');
+	const expectedCompletion = [
+		{ label: 'jgroups-raft:clusterName'}
+	];
+
+	afterEach(() => {
+		let config = vscode.workspace.getConfiguration();
+		config.update('camel.Camel catalog version', undefined);
+	});
+
+	it('Updated Catalog version is reflected in completion', async () => {
+		await testCompletion(docUriXml, new vscode.Position(0, 21), {
+			items: expectedCompletion
+		});
+		let config = vscode.workspace.getConfiguration();
+		await config.update('camel.Camel catalog version', '2.22.0');
+		const actualCompletionList = await retrieveCompletionList(docUriXml, new vscode.Position(0, 21));
+		const actualCompletionLabelList = actualCompletionList.items.map(c => { return c.label; });
+		expect(actualCompletionLabelList).to.not.include('jgroups-raft:clusterName');
+
+		await config.update('camel.Camel catalog version', undefined);
+		await testCompletion(docUriXml, new vscode.Position(0, 21), {
+			items: expectedCompletion
+		});
+	});
+
+});
+
+async function testCompletion(
+	docUri: vscode.Uri,
+	position: vscode.Position,
+	expectedCompletionList: vscode.CompletionList
+) {
+	await activate(docUri);
+
+	const actualCompletionList = await retrieveCompletionList(docUri, position);
+
+	const expectedCompletionLabelList = expectedCompletionList.items.map(c => { return c.label; });
+	const actualCompletionLabelList = actualCompletionList.items.map(c => { return c.label; });
+	expect(actualCompletionLabelList).to.include.members(expectedCompletionLabelList);
+	expect(actualCompletionLabelList).to.not.include('test:name');
+}
+async function retrieveCompletionList(docUri: vscode.Uri, position: vscode.Position) {
+	// Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
+	return (await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', docUri, position)) as vscode.CompletionList;
+}
+

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -5,10 +5,12 @@ async function runTest() {
 	try {
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
 		const extensionTestsPath = path.resolve(__dirname, './');
+		const testWorkspace = path.resolve(__dirname, '../../../testFixture');
 
 		await runTests({
 			extensionDevelopmentPath,
-			extensionTestsPath
+			extensionTestsPath,
+			launchArgs: [testWorkspace]
 		})
 	} catch (err) {
 		console.error('Failed to run tests!')

--- a/testFixture/test-catalog-version.xml
+++ b/testFixture/test-catalog-version.xml
@@ -1,0 +1,1 @@
+<from uri="jgroups-raft" xmlns="http://camel.apache.org/schema/blueprint"></from>


### PR DESCRIPTION
Please note that the format send to the server side contains an extra
layer of "camel". It is to follow-up
conventions of xml and Java Language server implementations. It also
allows in the future to potentially read properties of other Languages.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

requires https://github.com/camel-tooling/camel-language-server/pull/324

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build