### PR TITLE
FUSETOOLS2-490 - use rhel8 instead of rhel7 for Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
@@ -49,7 +49,7 @@ node('rhel7'){
     }
 }
 
-node('rhel7'){
+node('rhel8'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'apupier,lheinema,bfitzpat,tsedmik,djelinek'


### PR DESCRIPTION
to workaround https://github.com/microsoft/vscode/issues/99492

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build