### PR TITLE
FUSETOOLS2-433 - reuse VS Code settings for java.home to launch Camel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.0.25
 
+- Use 'java.home' VS Code settings if provided to launch the Camel Language Server. Defaults to system path if not. (previously requiring java on system path)
+
 ## 0.0.24
 
 - Diagnostic inside Camel Properties file
@@ -20,7 +22,7 @@
 
 ## 0.0.21
 
-- In Properties file, completion for possible enum values and booleans of a Camel component property 
+- In Properties file, completion for possible enum values and booleans of a Camel component property
 - In Properties file, the default values are automatically added when auto-completing Camel component properties
 - In Properties file, provide filtered completion when in middle of a component id, component property or value. Previously, completion was available only right after the dot or equal separators.
 - In Properties file, support insert-and-replace completion

--- a/src/JavaManager.ts
+++ b/src/JavaManager.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+import { workspace } from 'vscode';
+
+/**
+ * Use java from java.home configured in VS Code settings if available, otherwise, expect java to be available on the system path
+ */
+export function retrieveJavaExecutable() {
+	const javaHomeSetting = workspace.getConfiguration().inspect<string>('java.home');
+	const workspaceJavaHome = javaHomeSetting.workspaceValue;
+	if (workspaceJavaHome) {
+		return workspaceJavaHome + '/bin/java';
+	} else {
+		const globalJavaHome = javaHomeSetting.globalValue;
+		if(globalJavaHome){
+			return globalJavaHome + '/bin/java';
+		} else {
+			return 'java';
+		}
+	}
+}

--- a/src/JavaManager.ts
+++ b/src/JavaManager.ts
@@ -21,16 +21,10 @@ import { workspace } from 'vscode';
  * Use java from java.home configured in VS Code settings if available, otherwise, expect java to be available on the system path
  */
 export function retrieveJavaExecutable() {
-	const javaHomeSetting = workspace.getConfiguration().inspect<string>('java.home');
-	const workspaceJavaHome = javaHomeSetting.workspaceValue;
-	if (workspaceJavaHome) {
-		return workspaceJavaHome + '/bin/java';
+	const javaHomeSetting = workspace.getConfiguration().get('java.home');
+	if (javaHomeSetting) {
+		return javaHomeSetting + '/bin/java';
 	} else {
-		const globalJavaHome = javaHomeSetting.globalValue;
-		if(globalJavaHome){
-			return globalJavaHome + '/bin/java';
-		} else {
-			return 'java';
-		}
+		return 'java';
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import * as path from 'path';
 import { workspace, ExtensionContext, window, StatusBarAlignment, commands, ViewColumn, TextEditor, languages } from 'vscode';
 import { LanguageClient, LanguageClientOptions, Executable, DidChangeConfigurationNotification } from 'vscode-languageclient';
+import { retrieveJavaExecutable } from './JavaManager';
 
 var os = require('os');
 var storagePath;
@@ -22,12 +23,11 @@ export function activate(context: ExtensionContext) {
 		storagePath = getTempWorkspace();
 	}
 
-	var path = require('path');
-	var camelLanguageServerPath = context.asAbsolutePath(path.join('jars','language-server.jar'));
+	const camelLanguageServerPath = context.asAbsolutePath(path.join('jars','language-server.jar'));
 	console.log(camelLanguageServerPath);
 
 	let serverOptions: Executable = {
-		command: 'java',
+		command: retrieveJavaExecutable(),
 		args: [ '-jar', camelLanguageServerPath]
 	};
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -14,7 +14,7 @@ export function run(): Promise<void> {
 	const testsRoot = path.resolve(__dirname, '..');
 
 	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+		glob('**/javamanager.test.js', { cwd: testsRoot }, (err, files) => {
 			if (err) {
 				return e(err);
 			}

--- a/src/test/javamanager.test.ts
+++ b/src/test/javamanager.test.ts
@@ -27,19 +27,20 @@ describe('Should use correct java executable', () => {
 	let previousWorkspaceConfig: string | undefined;
 	let previousGlobalConfig: string | undefined
 
-	beforeEach(() => {
-		let config = vscode.workspace.getConfiguration();
+	beforeEach(async () => {
+		const config = vscode.workspace.getConfiguration();
 		const javaHomeSetting = config.inspect<string>('java.home');
 		previousWorkspaceConfig = javaHomeSetting.workspaceValue;
 		previousGlobalConfig = javaHomeSetting.globalValue;
-		config.update('java.home', undefined, vscode.ConfigurationTarget.Workspace);
-		config.update('java.home', undefined, vscode.ConfigurationTarget.Global);
+		await config.update('java.home', undefined, vscode.ConfigurationTarget.Workspace);
+		await config.update('java.home', undefined, vscode.ConfigurationTarget.Global);
+		await config.update('java.home', undefined);
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		let config = vscode.workspace.getConfiguration();
-		config.update('java.home', previousWorkspaceConfig, vscode.ConfigurationTarget.Workspace);
-		config.update('java.home', previousGlobalConfig, vscode.ConfigurationTarget.Global);
+		await config.update('java.home', previousWorkspaceConfig, vscode.ConfigurationTarget.Workspace);
+		await config.update('java.home', previousGlobalConfig, vscode.ConfigurationTarget.Global);
 	});
 
 	it('With Workspace settings', async () => {

--- a/src/test/javamanager.test.ts
+++ b/src/test/javamanager.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import { retrieveJavaExecutable } from '../JavaManager';
+
+const expect = chai.expect;
+
+describe('Should use correct java executable', () => {
+
+	let previousWorkspaceConfig: string | undefined;
+	let previousGlobalConfig: string | undefined
+
+	beforeEach(() => {
+		let config = vscode.workspace.getConfiguration();
+		const javaHomeSetting = config.inspect<string>('java.home');
+		previousWorkspaceConfig = javaHomeSetting.workspaceValue;
+		previousGlobalConfig = javaHomeSetting.globalValue;
+		config.update('java.home', undefined, vscode.ConfigurationTarget.Workspace);
+		config.update('java.home', undefined, vscode.ConfigurationTarget.Global);
+	});
+
+	afterEach(() => {
+		let config = vscode.workspace.getConfiguration();
+		config.update('java.home', previousWorkspaceConfig, vscode.ConfigurationTarget.Workspace);
+		config.update('java.home', previousGlobalConfig, vscode.ConfigurationTarget.Global);
+	});
+
+	it('With Workspace settings', async () => {
+		let config = vscode.workspace.getConfiguration();
+		await config.update('java.home', '/a/dummy/workspace/path', vscode.ConfigurationTarget.Workspace);
+		expect(retrieveJavaExecutable()).to.equal('/a/dummy/workspace/path/bin/java');
+	});
+
+	it('With Global settings', async () => {
+		let config = vscode.workspace.getConfiguration();
+		await config.update('java.home', '/a/dummy/global/path', vscode.ConfigurationTarget.Global);
+		expect(retrieveJavaExecutable()).to.equal('/a/dummy/global/path/bin/java');
+	});
+
+	it('With Workspace and Global settings', async () => {
+		let config = vscode.workspace.getConfiguration();
+		await config.update('java.home', '/a/dummy/workspace/path', vscode.ConfigurationTarget.Workspace);
+		await config.update('java.home', '/a/dummy/global/path', vscode.ConfigurationTarget.Global);
+		expect(retrieveJavaExecutable()).to.equal('/a/dummy/workspace/path/bin/java');
+	});
+
+	it('With Global settings', async () => {
+		let config = vscode.workspace.getConfiguration();
+		await config.update('java.home', '/a/dummy/global/path');
+		expect(retrieveJavaExecutable()).to.equal('/a/dummy/global/path/bin/java');
+	});
+
+	it('Without settings at VS Code level', async () => {
+		expect(retrieveJavaExecutable()).to.equal('java');
+	});
+
+});


### PR DESCRIPTION
Language Server

it will allow users that don't have java available on system path to
rely on the java.home VS Code settings.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build