### PR TITLE
FUSETOOLS2-561 - use tagged Camel language Server 1.1.0

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var lsp_server_version = "1.1.0-SNAPSHOT";
+var lsp_server_version = "1.1.0";
 
 const download = require("mvn-artifact-download").default;
 const fs = require('fs');
 const path = require('path');
 
-download('com.github.camel-tooling:camel-lsp-server:' + lsp_server_version, './jars/', 'https://oss.sonatype.org/content/repositories/snapshots/').then((filename)=>{
+download('com.github.camel-tooling:camel-lsp-server:' + lsp_server_version, './jars/', 'https://oss.sonatype.org/content/repositories/releases/').then((filename)=>{
 	fs.renameSync(filename, path.join('.', 'jars', 'language-server.jar'));
 });


### PR DESCRIPTION
I think it would be nice to provide a release of VS Code Language support for Camel with a tagged version.