### PR TITLE
Remove npm install --ignore-script call in jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ node('rhel8'){
 		env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 		sh "java -version"
 
-		sh "npm install --ignore-scripts"
 		sh "npm ci"
 		sh "npm run vscode:prepublish"
 	}


### PR DESCRIPTION
it is no more needed for a while. it was removed from travis but not
from jenkins

see https://github.com/camel-tooling/camel-lsp-client-vscode/commit/b4ef8c367c06daba77c9ca9200706194b15257f4#diff-354f30a63fb0907d4ad57269548329e3

