### PR TITLE
Fusetools2 782 fix broken master and several pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "8"
+node_js: "lts/*"
 services:
   - xvfb
 before_install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7445,12 +7445,12 @@
         }
       }
     },
-    "vscode-extension-tester-locators": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.49.0.tgz",
-      "integrity": "sha512-I4k0Ph+r9v9x5ocre9mz2uwVNny+g464LP8wD13QxAHdeLjJHgniYKJibOQqhx+7d1y2/5nwlPKwGqH/4fGjuQ==",
-      "dev": true
-    },
+	"vscode-extension-tester-locators": {
+		"version": "1.50.0",
+		"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.50.0.tgz",
+		"integrity": "sha512-dxxsQZk9s/zxKIj5aLKqVYqdPMAfQW9rSCGMVuLK6Ac0EDnx2uMe99DthzrfCOiov5BEXdA1MoqCcydrBxxNRg==",
+		"dev": true
+	},
     "vscode-extension-tester-native": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/vscode-extension-tester-native/-/vscode-extension-tester-native-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,6 +487,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -4752,16 +4758,46 @@
       }
     },
     "monaco-page-objects": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.2.2.tgz",
-      "integrity": "sha512-Be6wLkG2kHgs5Nlsz0dqdMyeCVMku+HJZwGfeKJ00haIi1myHMGVte4nUJ8uirxK3orXqqHLcDfiXB4M2XGycw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.2.3.tgz",
+      "integrity": "sha512-9UCdNqUVwMf6OTwvGe33A0OiE6lYvcpv8vV6BefoLuvJhEL7OSgr4BQ0TqmDaUA2mpNCDN9viDnSa0utR3ED3g==",
       "dev": true,
       "requires": {
         "clipboardy": "^2.0.0",
         "compare-versions": "^3.5.1",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "merge-deep": "github:jrichter1/merge-deep#functions",
-        "ts-essentials": "^3.0.5"
+        "ts-essentials": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -6821,9 +6857,9 @@
       }
     },
     "ts-essentials": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-3.0.5.tgz",
-      "integrity": "sha512-2aZyDplUuZ44ABrP9Z8kWzgrCLgntyro+WZMXgJOp5Lhx7e/N3eIDeDQUOHNUKDVyGrGtlOYy1WMkOrZBqLiUA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.0.tgz",
+      "integrity": "sha512-DptrzFAwb5afnsTdKxfScHqLbVZHl7YsxvDT+iT8tbXWFGSzbXALhfWlal25HBesqlX0NZd6wz9KBGnJcWScdQ==",
       "dev": true
     },
     "tslib": {
@@ -7056,9 +7092,9 @@
       }
     },
     "unzip-stream": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.0.tgz",
-      "integrity": "sha512-NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
+      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
       "dev": true,
       "requires": {
         "binary": "^0.3.0",
@@ -7310,15 +7346,15 @@
       }
     },
     "vscode-extension-tester": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-3.2.0.tgz",
-      "integrity": "sha512-h49U3mKqwLWeef2l7T24if0yA+VqxtbOanPqjoCsQl6Qttb6LUVzkxWgDINPax+bJERuCEEAt+koCHI7dGuKpA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-3.2.1.tgz",
+      "integrity": "sha512-vbUufgf2YFql1jVzBqC7vouK5mpExD5jme78VwMcouMs1TLsw4ueyIgVYXQo0UMsuHB/X9rYYmRPHTMEINyyqQ==",
       "dev": true,
       "requires": {
         "@types/selenium-webdriver": "^3.0.15",
-        "commander": "^5.0.0",
+        "commander": "^6.1.0",
         "compare-versions": "^3.6.0",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
         "js-yaml": "^3.13.1",
         "monaco-page-objects": "^1.0.0-0",
@@ -7326,22 +7362,93 @@
         "selenium-webdriver": "^3.0.0",
         "targz": "^1.0.1",
         "unzip-stream": "^0.3.0",
-        "vsce": "^1.71.0",
+        "vsce": "^1.81.0",
         "vscode-extension-tester-locators": "^1.44.0"
       },
       "dependencies": {
         "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
+        "vsce": {
+          "version": "1.81.1",
+          "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz",
+          "integrity": "sha512-1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==",
+          "dev": true,
+          "requires": {
+            "azure-devops-node-api": "^7.2.0",
+            "chalk": "^2.4.2",
+            "cheerio": "^1.0.0-rc.1",
+            "commander": "^6.1.0",
+            "denodeify": "^1.2.1",
+            "glob": "^7.0.6",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.15",
+            "markdown-it": "^10.0.0",
+            "mime": "^1.3.4",
+            "minimatch": "^3.0.3",
+            "osenv": "^0.1.3",
+            "parse-semver": "^1.1.1",
+            "read": "^1.0.7",
+            "semver": "^5.1.0",
+            "tmp": "0.0.29",
+            "typed-rest-client": "1.2.0",
+            "url-join": "^1.1.0",
+            "yauzl": "^2.3.1",
+            "yazl": "^2.2.2"
+          }
         }
       }
     },
     "vscode-extension-tester-locators": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.47.0.tgz",
-      "integrity": "sha512-RUOtYJ68Uqm4rTGBgKrr4ZckaNyP7wc51g01DoOjckmog56BxTFgJax04xov2feL4xwFp0kfNw2d8gBsKmC5aw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.49.0.tgz",
+      "integrity": "sha512-I4k0Ph+r9v9x5ocre9mz2uwVNny+g464LP8wD13QxAHdeLjJHgniYKJibOQqhx+7d1y2/5nwlPKwGqH/4fGjuQ==",
       "dev": true
     },
     "vscode-extension-tester-native": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "tslint": "^6.1.3",
     "typescript": "^4.0.3",
     "vsce": "^1.80.0",
-    "vscode-extension-tester": "^3.2.0",
+    "vscode-extension-tester": "^3.2.1",
     "vscode-extension-tester-native": "^3.0.0",
     "vscode-test": "^1.4.0",
     "vscode-uitests-tooling": "^2.0.1"


### PR DESCRIPTION
master is broken since release of VS Code 1.50.0.
To fix it, it requires to upgrade vscode-extension-tester to 3.2.1.
A manual upgrade of vscode-extension-tester-locator in package-lock.json is required as dependabot didn't want to pick it for unknown reasons.
This new version of vscode-extension-tester requires a newer version of fs-extra 9.0.1.
The fs-extra 9+ requires a newer version of node (10+) so need to update the Travis configuration (updated to lts/*, so currently 12).
Last built not least, the cache of Travis needed to be cleared.