### PR TITLE
Upgrade to JDK 11 for jenkins requirements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node('rhel8'){
 	}
 
 	stage('Build') {
-		env.JAVA_HOME="${tool 'openjdk-1.8'}"
+		env.JAVA_HOME="${tool 'openjdk-11'}"
 		env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 		sh "java -version"
 


### PR DESCRIPTION
VS Code Java requires java 11 for some time now but last release now
enforces it for more actions which is causin gour tests to break

