### PR TITLE
FUSETOOLS2-1190 - increase timeout to stabilize test

### DIFF
--- a/src/ui-test/xml_completion_support_test.ts
+++ b/src/ui-test/xml_completion_support_test.ts
@@ -32,7 +32,7 @@ describe('XML DSL support', function () {
 	}
 
 	const _clean = async function () {
-		this.timeout(6000);
+		this.timeout(12000);
 		const titleBar = new TitleBar();
 		await titleBar.select('File', 'Revert File');
 		const driver = VSBrowser.instance.driver;


### PR DESCRIPTION
based on this log with added traces from this other [PR](https://github.com/camel-tooling/camel-lsp-client-vscode/pull/662):

```
     ✓ Duplicate endpoint options are filtered out (18021ms)
clicked on File > Revert File . Time since beginning of _clean method: 2809
Editor is no more dirty . Time since beginning of _clean method: 2869
clicked on File > Close Editor . Time since beginning of _clean method: 5452
    Diagnostics for Camel URIs
      ✓ LSP diagnostics support for XML DSL (17775ms)
clicked on File > Revert File . Time since beginning of _clean method: 3231
Editor is no more dirty . Time since beginning of _clean method: 3292
      2) "after all" hook: _clean for "LSP diagnostics support for XML DSL"
    Auto-completion for referenced components IDs
clicked on File > Close Editor . Time since beginning of _clean method: 6130
      ✓ Auto-completion for referenced ID of "direct" component (4168ms)
      ✓ Auto-completion for referenced ID of "direct-vm" component (4204ms)
clicked on File > Revert File . Time since beginning of _clean method: 3113
Editor is no more dirty . Time since beginning of _clean method: 3179
      3) "after all" hook: _clean for "Auto-completion for referenced ID of "direct-vm" component"
clicked on File > Close Editor . Time since beginning of _clean method: 7199
```

the problem is that the clean is often taking between 6 and 8 seconds. (Which is a lot!!!!!)