### PR TITLE
FUSETOOLS2-1198 - use built-in caching mechanism for npm

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -20,19 +20,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-    - uses: actions/cache@v2
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
     - name: Install global dependencies
       run: npm install -g typescript vsce
     - name: npm-ci


### PR DESCRIPTION
cache usage can be noticed on this line https://github.com/camel-tooling/camel-lsp-client-vscode/runs/3142269896?check_suite_focus=true#step:4:16 on a rerun build.

it seems to be slightly faster: 5'31" compared to other comparable ones (a master build without modificatiosn to package-lock.json) which are between 5'45" and 5'52"
The main advantage is that it is a lot more readable