### PR TITLE
FUSETOOLS2-1158 - improve status bar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Java 1.8 to launch the embedded Camel Language Server is now deprecated. In 0.0.36, Java 11 will be the minimal version required.
 - Camel routes written in Java can now be folded in source code editor
+- Improve StatusBar message
 
 ## 0.0.34
 
@@ -14,7 +15,7 @@
 - Use Kamelet Catalog 0.3.0 instead of snapshot version
 - Adapt for Camel K community 1.5/Camel K Red Hat 1.4
   - Provide completion for new Camel K modeline option names
-  - Provide completion for the different kinds of `config` and `resource` Camel K modeline options (`configmap`, `secret`, `file`) 
+  - Provide completion for the different kinds of `config` and `resource` Camel K modeline options (`configmap`, `secret`, `file`)
   - Provide quick action to convert from deprecated `property-file` to `property=file:` notation
   - Propose completion for `file:` notation on `property` Camel K modeline option
   - Provide local file system properties file path as completion after `property=file:`, `resource=file:` and `config=file:` Camel K modeline option

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,16 +55,23 @@ export async function activate(context: ExtensionContext) {
 	};
 
 	let item = window.createStatusBarItem(StatusBarAlignment.Right, Number.MIN_VALUE);
-	item.text = 'Starting Apache Camel Language Server...';
+	item.name = 'Camel Language Server'
+	item.text = 'Camel LS $(sync~spin)';
+	item.tooltip = 'Language Server for Apache Camel is starting...';
 	toggleItem(window.activeTextEditor, item);
 	// Create the language client and start the client.
 	let languageClient = new LanguageClient(LANGUAGE_CLIENT_ID, 'Language Support for Apache Camel', serverOptions, clientOptions);
 	languageClient.onReady().then(() => {
-		item.text = 'Apache Camel Language Server started';
+		item.text = 'Camel LS $(thumbsup)';
+		item.tooltip = 'Language Server for Apache Camel started';
 		toggleItem(window.activeTextEditor, item);
 		commands.registerCommand('apache.camel.open.output', ()=>{
 		languageClient.outputChannel.show();
-	}, error => {console.log(error)});
+	}, error => {
+		item.text = 'Camel LS $(thumbsdown)';
+		item.tooltip = 'Language Server for Apache Camel failed to start';
+		console.log(error)
+	});
 
 	window.onDidChangeActiveTextEditor((editor) =>{
 		toggleItem(editor, item);

--- a/src/ui-test/lsp_extension_test.ts
+++ b/src/ui-test/lsp_extension_test.ts
@@ -21,7 +21,7 @@ describe('Language Support for Apache Camel extension', function () {
 
 	const RESOURCES: string = path.resolve('src', 'ui-test', 'resources');
 	const CAMEL_CONTEXT_XML: string = 'camel-context.xml';
-	const LSP_STATUS_BAR_MESSAGE: string = 'Apache Camel Language Server started';
+	const LSP_STATUS_BAR_MESSAGE: string = 'Camel LS ';
 
 	describe('Extensions view', function () {
 		let marketplace: Marketplace;
@@ -76,10 +76,17 @@ describe('Language Support for Apache Camel extension', function () {
 		});
 
 		it('Language Support for Apache Camel started', async function () {
-			await driver.wait(until.elementLocated(By.id('redhat.vscode-apache-camel')), 35000);
+			const lsp = await driver.wait(until.elementLocated(By.id('redhat.vscode-apache-camel')), 35000);
 			await driver.wait(async () => {
-				const lsp = await new StatusBarExt().getLSPSupport().catch(() => '');
-				return lsp === LSP_STATUS_BAR_MESSAGE;
+				const text = await lsp.getText().catch(() => '');
+				try {
+					const codicon = await lsp.findElement(By.className('codicon'))
+					const klass = await codicon.getAttribute('class');
+					return text.startsWith('Camel LS') && klass.includes('codicon-thumbsup');
+				}
+				catch {
+					return false;
+				}
 			}, this.timeout() - 3000, `Could not find Apache Camel element with label "${LSP_STATUS_BAR_MESSAGE}". Current label: "${await new StatusBarExt().getLSPSupport().catch(() => 'unknown')}"`);
 		});
 	});


### PR DESCRIPTION
- use specific naming to improve readability in right-click status bar
- shortened status bar text
- provided tooltip
- use icon for running/OK/KO in status bar state for Camel Language
Server
- reactivate status bar UI test by using conditional to avoid flakiness
(which was the reason of deactivation)

![statusBarImprovement](https://user-images.githubusercontent.com/1105127/127660849-88625eec-4c47-41b5-a07a-6e05cb33b5ce.gif)

![ImprovedNamingToHideShowStatusBaritem](https://user-images.githubusercontent.com/1105127/127661043-ddf7e281-05cf-4f5c-8e1a-6a1485e85eba.png)
