### PR TITLE
FUSETOOLS2-1229 - deprecation message in changelog and readme for java

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.0.35
 
+- Java 1.8 to launch the embedded Camel Language Server is now deprecated. In 0.0.36, Java 11 will be the minimal version required.
 - Camel routes written in Java can now be folded in source code editor
 
 ## 0.0.34

--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,8 @@ After you install VS Code, follow these steps:
 
 ## Requirements for using this extension
 
+* Java 1.8 is currently required to launch the Camel Language Server. It is deprecated in 0.0.35. Java 11 will be required in 0.0.36.
+
 After you install this **Language Support for Apache Camel** extension, follow these guidelines to access its features:
 
 For an XML DSL file:


### PR DESCRIPTION
1.8 to launch Camel Language Server

