### PR TITLE
Prepare next development iteration 0.0.36

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 0.0.36
+
 ## 0.0.35
 
 - Update default Camel Catalog version from 3.11.0 to 3.11.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-apache-camel",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Language Support for Apache Camel by Red Hat",
   "description": "Provides completion and documentation features for Apache Camel URI elements in XML DSL.",
   "license": "Apache-2.0",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "preview": true,
   "publisher": "redhat",
   "icon": "icons/icon128.png",


### PR DESCRIPTION
keeping to 0.0.36 scheme for now. Will upgrade to 0.1.0 when the Camel Languaeg Server used will effectively requires Java 11