### PR TITLE
FUSETOOLS2-1229 - upgrade Camel Language Server to 1.3.0-SNAPSHOT

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## 0.0.36
+## 0.1.0
+
+- Java 11 is required to launch the embedded Camel Language Server.
 
 ## 0.0.35
 

--- a/Readme.md
+++ b/Readme.md
@@ -139,7 +139,7 @@ After you install VS Code, follow these steps:
 
 ## Requirements for using this extension
 
-* Java 1.8 is currently required to launch the Camel Language Server. It is deprecated in 0.0.35. Java 11 will be required in 0.0.36.
+* Java 11 is currently required to launch the Camel Language Server. The `java.home` VS Code preferences can be used to use a different version of JDK than the default one installed on the machine.
 
 After you install this **Language Support for Apache Camel** extension, follow these guidelines to access its features:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-apache-camel",
-  "version": "0.0.36",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Language Support for Apache Camel by Red Hat",
   "description": "Provides completion and documentation features for Apache Camel URI elements in XML DSL.",
   "license": "Apache-2.0",
-  "version": "0.0.36",
+  "version": "0.1.0",
   "preview": true,
   "publisher": "redhat",
   "icon": "icons/icon128.png",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var lsp_server_version = "1.2.0-SNAPSHOT";
+var lsp_server_version = "1.3.0-SNAPSHOT";
 
 const download = require("mvn-artifact-download").default;
 const fs = require('fs');


### PR DESCRIPTION
It requires Java 11 thus increasing the version number

If Java 8 is configured locally, there are these errors available:
![Screenshot from 2021-09-02 13-35-11](https://user-images.githubusercontent.com/1105127/131837500-46783e03-3b2c-490f-bf80-f62128566c90.png)

provided a wiki page to troubleshoot this issue https://github.com/camel-tooling/camel-lsp-client-vscode/wiki/Troubleshooting

It might be enough to guide users. At least as a first iteration. Another iteration could provide a notification mentioning that Java 11 is required like Tools for Microprofile is doing.


