### PR TITLE
Launch VS Code tests with several VS Code versions

### DIFF
--- a/.github/workflows/vscode-versions-matrix.yml
+++ b/.github/workflows/vscode-versions-matrix.yml
@@ -1,0 +1,41 @@
+name: Test matrixes of VS Code versions
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        vscode-version: ["1.57.0", "1.60.0"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+        cache: 'npm'
+    - name: Install global dependencies
+      run: npm install -g typescript vsce
+    - name: npm-ci
+      run: npm ci
+    - name: npm-compile
+      run: npm run compile
+    - name: test
+      run: xvfb-run -a npm test
+      env:
+          CODE_VERSION: ${{ matrix.vscode-version }}
+    - name: ui-test
+      env:
+          CODE_VERSION: ${{ matrix.vscode-version }}
+      run: xvfb-run -a npm run ui-test

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -8,7 +8,9 @@ async function runTest() {
 		const extensionTestsPath = path.resolve(__dirname, './');
 		const testWorkspace = path.resolve(__dirname, '../../../test Fixture with speci@l chars');
 
-		const vscodeExecutablePath : string = await downloadAndUnzipVSCode('stable');
+		let vscodeVersion = computeVSCodeVersionToPlayTestWith();
+
+		const vscodeExecutablePath : string = await downloadAndUnzipVSCode(vscodeVersion);
 		console.log(`vscodeExecutablePath = ${vscodeExecutablePath}`);
 
 		const cliPath: string = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
@@ -26,6 +28,14 @@ async function runTest() {
 	} catch (err) {
 		console.error('Failed to run tests!')
 		process.exit(1)
+	}
+
+	function computeVSCodeVersionToPlayTestWith() {
+		const envVersion = process.env.CODE_VERSION;
+		if (envVersion) {
+			return envVersion;
+		}
+		return 'stable';
 	}
 }
 


### PR DESCRIPTION
Launch VS Code tests with several VS Code versions

- using Github Action as ti is a lot simpler than Circle CI
- launching with first compatible version declared and latest known

The idea is to potentially test older versions so that it has compatible APIs with Theia/Che/CodeReady Workspaces.  it doesn't solve the problem of potential CVEs.