### PR TITLE
FUSETOOLS2-1297 - migrate default branch name from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           path: /home/circleci/camel-lsp-client-vscode/test-resources/screenshots
       - when:
           condition:
-            equal: [master, << pipeline.git.branch >>]
+            equal: [main, << pipeline.git.branch >>]
           steps:
             - sonarcloud/scan
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Rebase & Merge default requirements
 
-1. Green build for master branch
+1. Green build for main branch
 2. Wait 24 hours after PR creation
 3. Green job for PR
 4. Approved PR
@@ -22,4 +22,4 @@
 1. [ ] Tagged with relevant **PR labels**
 2. [ ] Green **job for PR**
 3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
-4. [ ] Green **master** branch build
+4. [ ] Green **main** branch build

--- a/.github/workflows/vscode-versions-matrix.yml
+++ b/.github/workflows/vscode-versions-matrix.yml
@@ -2,9 +2,9 @@ name: Test matrixes of VS Code versions
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -5,9 +5,9 @@ name: Test on Windows
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,7 @@ When you add this extension to your installation of VS Code, the VS Code editor 
 
 It is possible to use a specific Camel Catalog version. This can be specified in **File -> Preferences -> Settings -> Apache Camel Tooling -> Camel catalog version**
 
-To use a Red Hat integration productized version, you need to configure extra repositories. See in [Camel Language Server documentation](https://github.com/camel-tooling/camel-language-server/blob/master/README.md#specific-version-of-camel-catalog).
+To use a Red Hat integration productized version, you need to configure extra repositories. See in [Camel Language Server documentation](#specific-version-of-camel-catalog).
 
 It is possible to use a specific Runtime provider for the Camel catalog. This can be specified in **File -> Preferences -> Settings -> Apache Camel Tooling -> Camel catalog runtime provider**
 


### PR DESCRIPTION
Requires the default branch migrated from `master` to `main` in GitHub Web UI before merging.
to synchronize with https://gitlab.cee.redhat.com/codeready-studio/cci-config/-/merge_requests/450