### PR TITLE
FUSETOOLS2-1338 - detect missing dependencies at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "tsc -p ./ && npm run tslint",
     "watch": "tsc -watch -p ./",
     "postinstall": "node ./scripts/postinstall.js",
     "test": "node ./out/src/test/runTest.js",

--- a/tslint.json
+++ b/tslint.json
@@ -8,9 +8,10 @@
 		"class-name": true,
 		"semicolon": ["always"],
 		"triple-equals": true,
-		"quotemark": [true, "single", "avoid-escape"]
+		"quotemark": [true, "single", "avoid-escape"],
+		"no-implicit-dependencies": [true, "dev", ["vscode"]]
 	},
 	"linterOptions": {
-		"exclude": ["test-resources"]
+		"exclude": ["test-extensions/**", "test-resources/**"]
 	}
 }


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-lsp-client-vscode/pull/798

- use specific ts-lint configuration. Avoid checking inside the UI tests
resource folders which has node_modules that we do not want to be
analyzed
- ensure ts-lint is called on compilation

the goal is to avoid missing implicit dependencies which are leaking
from devDependencies and so missing at runtime with a built vsix (and
not detected by tests execution)