### PR TITLE
FUSETOOLS2-1359 - avoid use of sudo to install global npm dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Install global npm dependencies
           command: |
-            sudo npm install -g typescript vsce
+            npm install --prefix=$HOME/.local -g typescript vsce
       - run:
           name: npm-ci
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             npm install --prefix=$HOME/.local -g typescript vsce
       - run:
           name: npm-ci
-          command: npm ci
+          command: npm ci --prefix=$HOME/.local
       - run:
           name: npm-vscode:prepublish
           command: npm run vscode:prepublish


### PR DESCRIPTION
on Circle CI

it was previously required, now it is causing build failures

