### PR TITLE
FUSETOOLS2-1359 - use node 14.18 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Install global npm dependencies
           command: |
-            sudo npm install -g typescript vsce
+            npm install --prefix=$HOME/.local -g typescript vsce
       - run:
           name: npm-ci
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     working_directory: ~/camel-lsp-client-vscode
     docker:
-      - image: cimg/node:lts-browsers
+      - image: cimg/node:14.18-browsers
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
- lt had been upgraded automatically to 16.x. it is causing trouble with global
dependencies and opencv doesn't contain prebuilt versions
- FUSETOOLS2-1359 - avoid use of sudo to install global npm dependencies on Circle C. It was previously required, now it is causing build failures. see https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation
for workaround
