### PR TITLE
FUSETOOLS2-1677 - improve support for productized catalog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Update Kamelet Catalog from 0.8.0 to 0.8.1
 - Requires VS Code 1.67+
 - Added completion option to add Camel K modeline on new files
+- Support of Red Hat productized classic Camel Catalog (not Kamelet)
 
 ## 0.3.0
 

--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,11 @@ When you add this extension to your installation of VS Code, the VS Code editor 
 
 It is possible to use a specific Camel Catalog version. This can be specified in **File -> Preferences -> Settings -> Apache Camel Tooling -> Camel catalog version**
 
-To use a Red Hat integration productized version, you need to configure extra repositories. See in [Camel Language Server documentation](#specific-version-of-camel-catalog).
+Please note that the first time a version is used, it can take several seconds/minutes to have it available depending on the time to download the dependencies in the background.
+
+When using a Red Hat productized version which contains `redhat` in the version, the Maven Red Hat repository is automatically added.
+
+To use other versions not available on Maven Central, you need to configure extra repositories. See in [Camel Language Server documentation](#specific-version-of-camel-catalog).
 
 It is possible to use a specific Runtime provider for the Camel catalog. This can be specified in **File -> Preferences -> Settings -> Apache Camel Tooling -> Camel catalog runtime provider**
 


### PR DESCRIPTION
Only the classic catalog is covered. It allows to cover the Camel
Quarkus use case. It will cover the SpringBoot based use case when it
will be productized.

requires https://github.com/camel-tooling/camel-language-server/pull/784