### PR TITLE
Changelog upgrade Camel default catalog from 3.18.0 to 3.18.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.5.0
 
+- Update default Camel Catalog version from 3.18.0 to 3.18.1
 - Update Camel Quarkus Catalog from 2.10.0 to 2.12.0
 - Added urls to review available Camel Catalog to the settings
 


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-language-server/pull/816