### PR TITLE
Stabilize UI test for Extensions

### DIFF
--- a/src/ui-test/tests/lsp_extension.test.ts
+++ b/src/ui-test/tests/lsp_extension.test.ts
@@ -33,6 +33,7 @@ import {
 	Marketplace,
 	StatusBar
 } from 'vscode-uitests-tooling';
+import { fail } from 'assert';
 
 describe('Language Support for Apache Camel extension', function () {
 	this.timeout(60000);
@@ -56,7 +57,12 @@ describe('Language Support for Apache Camel extension', function () {
 
 		it('Find extension', async function () {
 			this.retries(5);
-			item = await marketplace.findExtension(`@installed ${pjson.displayName}`);
+			try {
+				item = await marketplace.findExtension(`@installed ${pjson.displayName}`);
+			} catch (error) {
+				console.log(error);
+				fail(`Unable to find the extension: ${error}`)
+			}
 		});
 
 		it('Extension is installed', async function () {

--- a/src/ui-test/tests/lsp_extension.test.ts
+++ b/src/ui-test/tests/lsp_extension.test.ts
@@ -46,7 +46,6 @@ describe('Language Support for Apache Camel extension', function () {
 		let item: ExtensionsViewItem;
 
 		before(async function () {
-			this.retries(5);
 			marketplace = await Marketplace.open(this.timeout());
 		});
 
@@ -56,6 +55,7 @@ describe('Language Support for Apache Camel extension', function () {
 		});
 
 		it('Find extension', async function () {
+			this.retries(5);
 			item = await marketplace.findExtension(`@installed ${pjson.displayName}`);
 		});
 


### PR DESCRIPTION
it helps to stabilize Extensions UI tests. Now for some of the previous flaky tests, there is only a log provided and test is waiting a bit more and retrying.

https://github.com/camel-tooling/camel-lsp-client-vscode/actions/runs/5004091638/jobs/9046385267#step:14:80
```
     Extensions view
TimeoutError: Wait timed out after 10113ms
    at /home/runner/work/camel-lsp-client-vscode/camel-lsp-client-vscode/node_modules/selenium-webdriver/lib/webdriver.js:929:17
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  remoteStacktrace: ''
}
```

Oart of the various run, there were soem failures but none were related to the Extensions test.