### PR TITLE
Ignore .test-extensions folder used as extensions install path for UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ target
 log-camel-lsp.out
 test-resources
 test Fixture with speci@l chars/.vscode/**
-test-extensions
+.test-extensions

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,3 +20,4 @@ CONTRIBUTING.md
 test-resources
 test Fixture with speci@l chars/**
 testFixture/**
+.test-extensions

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 	"exclude": [
 		"node_modules",
 		".vscode-test",
-		"test-resources"
+		"test-resources",
+		".test-extensions"
 	]
 }


### PR DESCRIPTION
We are defining custom extensions dir path here - https://github.com/camel-tooling/camel-lsp-client-vscode/blob/main/src/ui-test/uitest_runner.ts#L26 so we need to ignore/exclude that in right places

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build
