### PR TITLE
Update default version of Camel to 3.20.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Provide command to create a Camel Quarkus project
 - Provide command to create a Camel on SpringBoot project
 - Update Kamelet Catalog from 3.20.4 to 3.20.5
+- Update default Camel Catalog version from 3.20.5 to 3.20.6
 
 ## 0.8.0
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "camel.languageSupport.JBangVersion": {
           "type": "string",
           "markdownDescription": "Apache Camel JBang version used for internal VS Code JBang commands execution. Camel JBang requirements can differ between versions, it is recommended to use `default` version to ensure all extension features work properly.\n\n**Note**: This change will affect only commands provided by Language Support for Apache Camel extension.",
-          "default": "3.20.5"
+          "default": "3.20.6"
         }
       }
     },


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-dap-client-vscode/pull/427