### PR TITLE
Improve robustness of tests after Camel 3.21.0 upgrade

### DIFF
--- a/src/test/suite/catalog.additional.component.test.ts
+++ b/src/test/suite/catalog.additional.component.test.ts
@@ -3,13 +3,17 @@
 import * as vscode from 'vscode';
 import { checkExpectedCompletion, checkNotExpectedCompletion } from './completion.util';
 import { getDocUri } from './helper';
+import waitUntil from 'async-wait-until';
 
 describe('Should do completion in Camel URI using the additional component specified in preference', () => {
 	const docUriXml = getDocUri('test-additional-component.xml');
 
-	afterEach(() => {
+	afterEach(async () => {
 		const config = vscode.workspace.getConfiguration();
-		config.update('camel.extra-components', undefined);
+		await config.update('camel.extra-components', undefined);
+		await waitUntil( async() =>  {
+			return ((await vscode.workspace.getConfiguration().get('camel.extra-components')) as []).length === 0;
+		});
 	});
 
 	it('Updated additional component is reflected in completion', async () => {
@@ -25,6 +29,10 @@ describe('Should do completion in Camel URI using the additional component speci
 				'syntax': 'acomponent:withsyntax'
 			}
 		}]);
+
+		await waitUntil( async() =>  {
+			return (await vscode.workspace.getConfiguration().get('camel.extra-components')) !== undefined;
+		});
 		await checkExpectedCompletion(docUriXml, positionToCallCompletion, completionItemLabel);
 
 		await config.update('camel.extra-components', undefined);

--- a/src/test/suite/catalog.runtimeprovider.test.ts
+++ b/src/test/suite/catalog.runtimeprovider.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as chai from 'chai';
 import { getDocUri, activate } from './helper';
 import { checkExpectedCompletion, checkNotExpectedCompletion } from './completion.util';
+import waitUntil from 'async-wait-until';
 
 const expect = chai.expect;
 
@@ -13,9 +14,12 @@ describe('Should do completion in Camel URI using the Camel Catalog version spec
 	const docUriXml = getDocUri('test-catalog-version.xml');
 	const expectedCompletion = { label: 'jgroups-raft:clusterName'};
 
-	afterEach(() => {
+	afterEach(async () => {
 		const config = vscode.workspace.getConfiguration();
-		config.update(RUNTIME_PROVIDER_SETTINGS_KEY, undefined);
+		await config.update(RUNTIME_PROVIDER_SETTINGS_KEY, undefined);
+		await waitUntil( async() =>  {
+			return (await vscode.workspace.getConfiguration().get(RUNTIME_PROVIDER_SETTINGS_KEY)) === '';
+		});
 	});
 
 	it('Updated Catalog runtime provider is reflected in completion', async () => {
@@ -24,6 +28,10 @@ describe('Should do completion in Camel URI using the Camel Catalog version spec
 		expect(config.get(RUNTIME_PROVIDER_SETTINGS_KEY)).to.not.be.equal('KARAF');
 		await checkExpectedCompletion(docUriXml, new vscode.Position(0, 21), expectedCompletion);
 		await config.update(RUNTIME_PROVIDER_SETTINGS_KEY, 'KARAF');
+
+		await waitUntil( async() =>  {
+			return (await vscode.workspace.getConfiguration().get(RUNTIME_PROVIDER_SETTINGS_KEY)) === 'KARAF';
+		});
 
 		await checkNotExpectedCompletion(docUriXml, new vscode.Position(0, 21), expectedCompletion);
 

--- a/src/test/suite/catalog.version.test.ts
+++ b/src/test/suite/catalog.version.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as chai from 'chai';
 import { getDocUri, activate } from './helper';
 import { checkExpectedCompletion, checkNotExpectedCompletion } from './completion.util';
+import { waitUntil } from 'async-wait-until';
 
 const expect = chai.expect;
 
@@ -11,9 +12,12 @@ describe('Should do completion in Camel URI using the Camel Catalog version spec
 	const docUriXml = getDocUri('test-catalog-version.xml');
 	const expectedCompletion = { label: 'jgroups-raft:clusterName'};
 
-	afterEach(() => {
+	afterEach(async () => {
 		const config = vscode.workspace.getConfiguration();
-		config.update('camel.Camel catalog version', undefined);
+		await config.update('camel.Camel catalog version', undefined);
+		await waitUntil( async() =>  {
+			return (await vscode.workspace.getConfiguration().get('camel.Camel catalog version')) === '';
+		});
 	});
 
 	it('Updated Catalog version is reflected in completion', async () => {
@@ -22,6 +26,10 @@ describe('Should do completion in Camel URI using the Camel Catalog version spec
 		expect(config.get('camel.Camel catalog version')).to.not.be.equal('2.22.0');
 		await checkExpectedCompletion(docUriXml, new vscode.Position(0, 21), expectedCompletion);
 		await config.update('camel.Camel catalog version', '2.22.0');
+
+		await waitUntil( async() =>  {
+			return (await vscode.workspace.getConfiguration().get('camel.Camel catalog version')) === '2.22.0';
+		});
 
 		await checkNotExpectedCompletion(docUriXml, new vscode.Position(0, 21), expectedCompletion);
 


### PR DESCRIPTION
https://github.com/apupier/camel-lsp-client-vscode/pull/new/ImproveRobustnessOfTestsAfterCamel3.21Upgrade- tests were failing only on Ubuntu on CI
- added conditional wait, they are not perfect for sure but allows tests to currently pass



