### PR TITLE
Remove redundant pre-uitest script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "postinstall": "node ./scripts/postinstall.js",
     "test": "node ./out/src/test/runTest.js",
     "lint": "eslint src --ext .ts",
-    "preui-test": "npm run compile",
     "ui-test": "node --unhandled-rejections=warn-with-error-code out/src/ui-test/uitest_runner.js"
   },
   "devDependencies": {


### PR DESCRIPTION
compile is done in `vscode-prepublish` step

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build
