### PR TITLE
Bump vscode-uitests-tooling from 4.0.3 to 4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rimraf": "^5.0.1",
         "sinon": "^15.2.0",
         "typescript": "^5.1.6",
-        "vscode-uitests-tooling": "^4.0.3"
+        "vscode-uitests-tooling": "^4.0.5"
       },
       "engines": {
         "vscode": "^1.76.0"
@@ -399,9 +399,9 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@sindresorhus/is": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.4.1.tgz",
-      "integrity": "sha512-axlrvsHlHlFmKKMEg4VyvMzFr93JWJj4eIfXY1STVuO2fsImCa7ncaiG5gC8HKOX590AW5RtRsC41/B+OfrSqw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -1705,15 +1705,15 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "10.2.12",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.12.tgz",
-      "integrity": "sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==",
+      "version": "10.2.13",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+      "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
       "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
         "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.2",
+        "keyv": "^4.5.3",
         "mimic-response": "^4.0.0",
         "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
@@ -2051,16 +2051,15 @@
       }
     },
     "node_modules/compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+      "integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -2072,8 +2071,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/countries-and-timezones": {
       "version": "3.4.1",
@@ -3172,8 +3170,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fstream": {
       "version": "1.0.12",
@@ -3732,8 +3729,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3764,7 +3760,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3773,8 +3768,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4122,8 +4116,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4220,7 +4213,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -4247,9 +4239,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4301,7 +4293,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -4894,14 +4885,14 @@
       }
     },
     "node_modules/monaco-page-objects": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.8.0.tgz",
-      "integrity": "sha512-/bsrTHul7KsZ1SmdQFHIdVZTU2Nr+odGpxZAJddWxanX1uEAreqE4H758wI9Ie3mZLFO798lPjv2zaUAi+kDFw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.9.0.tgz",
+      "integrity": "sha512-Hw5eJqYAhe/a83xziiIU113RVZ7vUOdyNCPxgjVN+JcKjuLzqgQcSRY0NRnQzfMmckpNUpNfcx6o1nKkiPZv4g==",
       "dev": true,
       "dependencies": {
         "clipboardy": "^3.0.0",
         "clone-deep": "^4.0.1",
-        "compare-versions": "^5.0.3",
+        "compare-versions": "^6.0.0",
         "fs-extra": "^11.1.1",
         "ts-essentials": "^9.3.2"
       },
@@ -5349,8 +5340,7 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5392,7 +5382,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5526,8 +5515,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5650,7 +5638,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5664,8 +5651,7 @@
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -5868,7 +5854,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.10.0.tgz",
       "integrity": "sha512-hSQPw6jgc+ej/UEcdQPG/iBwwMeCEgZr9HByY/J8ToyXztEqXzU9aLsIyrlj1BywBcStO4JQK/zMUWWrV8+riA==",
-      "dev": true,
       "dependencies": {
         "jszip": "^3.10.1",
         "tmp": "^0.2.1",
@@ -5906,8 +5891,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -6058,7 +6042,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6066,8 +6049,7 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-width": {
       "version": "1.0.2",
@@ -6381,7 +6363,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -6393,7 +6374,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6403,7 +6383,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6423,7 +6402,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6435,7 +6413,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6768,8 +6745,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -6791,26 +6767,26 @@
       }
     },
     "node_modules/vscode-extension-tester": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.8.0.tgz",
-      "integrity": "sha512-DMOSmxXnrREWqLXYYq+Au53n6/BAVbKbOPxAm7bmpuvMCyF6lKJk9olEsbbVMTugkIToLaafsh4LSq47bTgeHQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.9.0.tgz",
+      "integrity": "sha512-VMmq/fB6FyXK+ICeQpnZa+JeAuCZy9Xz1mo90iw8/eNZEjTYlZqfMSMBGMIJ0vvnHAf5XjEaemPte9JESmsoSw==",
       "dev": true,
       "dependencies": {
-        "@types/selenium-webdriver": "^4.1.12",
-        "@vscode/vsce": "^2.19.0",
+        "@types/selenium-webdriver": "^4.1.15",
+        "@vscode/vsce": "^2.20.0",
         "commander": "^11.0.0",
-        "compare-versions": "^5.0.1",
+        "compare-versions": "^6.0.0",
         "fs-extra": "^11.1.0",
         "glob": "^8.1.0",
         "got": "^13.0.0",
         "hpagent": "^1.2.0",
         "js-yaml": "^4.1.0",
-        "monaco-page-objects": "^3.8.0",
+        "monaco-page-objects": "^3.9.0",
         "sanitize-filename": "^1.6.3",
         "selenium-webdriver": "^4.10.0",
         "targz": "^1.0.1",
         "unzipper": "^0.10.14",
-        "vscode-extension-tester-locators": "^3.6.0"
+        "vscode-extension-tester-locators": "^3.7.0"
       },
       "bin": {
         "extest": "out/cli.js"
@@ -6821,12 +6797,12 @@
       }
     },
     "node_modules/vscode-extension-tester-locators": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.6.0.tgz",
-      "integrity": "sha512-RjQf5XL33dJORl9ck5X0vhAHf93TOONPE4nb9nai/pDM15nYcD1TqMyzRGl/XxHpvBu/bP8MV/bHfCT6b8w2cQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.7.0.tgz",
+      "integrity": "sha512-ML9RFOum8GoE4xggYNzUIanFOT4CWUDCK5LFraLEoJ+9rptA5PSLGC+uSPYVKNNU2pG946SPEC3ZJDetc/IeqA==",
       "dev": true,
       "peerDependencies": {
-        "monaco-page-objects": "^3.8.0",
+        "monaco-page-objects": "^3.9.0",
         "selenium-webdriver": "^4.6.1"
       }
     },
@@ -6910,9 +6886,9 @@
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "node_modules/vscode-uitests-tooling": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.3.tgz",
-      "integrity": "sha512-aVE/gDrRABIhbfVba9RXG1fZ+5nCLfmlNdhU9IWsFxA31uC3kXnRt7HXaJXMH35hjqKNJ+wCtaUZ7g9BRYKytA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.5.tgz",
+      "integrity": "sha512-GZvB/kTDrce7BGeFebhX+Ta967w457ByMoAcAxIWWUGhCBC7X+ahX4PRhzFAwxlNI5NED6mDpqBssOd9chP55Q==",
       "dev": true,
       "dependencies": {
         "chai": "^4.3.7",
@@ -6920,7 +6896,7 @@
         "fs-extra": "^11.1.1",
         "sanitize-filename": "^1.6.3",
         "tree-kill": "^1.2.2",
-        "vscode-extension-tester": "^5.8.0"
+        "vscode-extension-tester": "^5.9.0"
       },
       "peerDependencies": {
         "mocha": ">=5.2.0"
@@ -7128,7 +7104,6 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7549,9 +7524,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.4.1.tgz",
-      "integrity": "sha512-axlrvsHlHlFmKKMEg4VyvMzFr93JWJj4eIfXY1STVuO2fsImCa7ncaiG5gC8HKOX590AW5RtRsC41/B+OfrSqw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -8475,15 +8450,15 @@
       "dev": true
     },
     "cacheable-request": {
-      "version": "10.2.12",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.12.tgz",
-      "integrity": "sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==",
+      "version": "10.2.13",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+      "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
       "dev": true,
       "requires": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
         "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.2",
+        "keyv": "^4.5.3",
         "mimic-response": "^4.0.0",
         "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
@@ -8741,16 +8716,15 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+      "integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -8762,8 +8736,7 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "countries-and-timezones": {
       "version": "3.4.1",
@@ -9604,8 +9577,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
       "version": "1.0.12",
@@ -10005,8 +9977,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -10028,7 +9999,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10037,8 +10007,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -10266,8 +10235,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -10345,7 +10313,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -10371,9 +10338,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
@@ -10413,7 +10380,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -10855,14 +10821,14 @@
       }
     },
     "monaco-page-objects": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.8.0.tgz",
-      "integrity": "sha512-/bsrTHul7KsZ1SmdQFHIdVZTU2Nr+odGpxZAJddWxanX1uEAreqE4H758wI9Ie3mZLFO798lPjv2zaUAi+kDFw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-3.9.0.tgz",
+      "integrity": "sha512-Hw5eJqYAhe/a83xziiIU113RVZ7vUOdyNCPxgjVN+JcKjuLzqgQcSRY0NRnQzfMmckpNUpNfcx6o1nKkiPZv4g==",
       "dev": true,
       "requires": {
         "clipboardy": "^3.0.0",
         "clone-deep": "^4.0.1",
-        "compare-versions": "^5.0.3",
+        "compare-versions": "^6.0.0",
         "fs-extra": "^11.1.1",
         "ts-essentials": "^9.3.2"
       }
@@ -11191,8 +11157,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -11230,8 +11195,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -11333,8 +11297,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -11421,7 +11384,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11435,8 +11397,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -11569,7 +11530,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.10.0.tgz",
       "integrity": "sha512-hSQPw6jgc+ej/UEcdQPG/iBwwMeCEgZr9HByY/J8ToyXztEqXzU9aLsIyrlj1BywBcStO4JQK/zMUWWrV8+riA==",
-      "dev": true,
       "requires": {
         "jszip": "^3.10.1",
         "tmp": "^0.2.1",
@@ -11601,8 +11561,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shallow-clone": {
       "version": "3.0.1",
@@ -11702,7 +11661,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -11710,8 +11668,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -11964,7 +11921,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
       "requires": {
         "rimraf": "^3.0.0"
       },
@@ -11973,7 +11929,6 @@
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11983,7 +11938,6 @@
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
           "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -11997,7 +11951,6 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12006,7 +11959,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -12257,8 +12209,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "9.0.0",
@@ -12274,26 +12225,26 @@
       }
     },
     "vscode-extension-tester": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.8.0.tgz",
-      "integrity": "sha512-DMOSmxXnrREWqLXYYq+Au53n6/BAVbKbOPxAm7bmpuvMCyF6lKJk9olEsbbVMTugkIToLaafsh4LSq47bTgeHQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-5.9.0.tgz",
+      "integrity": "sha512-VMmq/fB6FyXK+ICeQpnZa+JeAuCZy9Xz1mo90iw8/eNZEjTYlZqfMSMBGMIJ0vvnHAf5XjEaemPte9JESmsoSw==",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "^4.1.12",
-        "@vscode/vsce": "^2.19.0",
+        "@types/selenium-webdriver": "^4.1.15",
+        "@vscode/vsce": "^2.20.0",
         "commander": "^11.0.0",
-        "compare-versions": "^5.0.1",
+        "compare-versions": "^6.0.0",
         "fs-extra": "^11.1.0",
         "glob": "^8.1.0",
         "got": "^13.0.0",
         "hpagent": "^1.2.0",
         "js-yaml": "^4.1.0",
-        "monaco-page-objects": "^3.8.0",
+        "monaco-page-objects": "^3.9.0",
         "sanitize-filename": "^1.6.3",
         "selenium-webdriver": "^4.10.0",
         "targz": "^1.0.1",
         "unzipper": "^0.10.14",
-        "vscode-extension-tester-locators": "^3.6.0"
+        "vscode-extension-tester-locators": "^3.7.0"
       },
       "dependencies": {
         "glob": {
@@ -12312,9 +12263,9 @@
       }
     },
     "vscode-extension-tester-locators": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.6.0.tgz",
-      "integrity": "sha512-RjQf5XL33dJORl9ck5X0vhAHf93TOONPE4nb9nai/pDM15nYcD1TqMyzRGl/XxHpvBu/bP8MV/bHfCT6b8w2cQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-3.7.0.tgz",
+      "integrity": "sha512-ML9RFOum8GoE4xggYNzUIanFOT4CWUDCK5LFraLEoJ+9rptA5PSLGC+uSPYVKNNU2pG946SPEC3ZJDetc/IeqA==",
       "dev": true,
       "requires": {}
     },
@@ -12366,9 +12317,9 @@
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "vscode-uitests-tooling": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.3.tgz",
-      "integrity": "sha512-aVE/gDrRABIhbfVba9RXG1fZ+5nCLfmlNdhU9IWsFxA31uC3kXnRt7HXaJXMH35hjqKNJ+wCtaUZ7g9BRYKytA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-4.0.5.tgz",
+      "integrity": "sha512-GZvB/kTDrce7BGeFebhX+Ta967w457ByMoAcAxIWWUGhCBC7X+ahX4PRhzFAwxlNI5NED6mDpqBssOd9chP55Q==",
       "dev": true,
       "requires": {
         "chai": "^4.3.7",
@@ -12376,7 +12327,7 @@
         "fs-extra": "^11.1.1",
         "sanitize-filename": "^1.6.3",
         "tree-kill": "^1.2.2",
-        "vscode-extension-tester": "^5.8.0"
+        "vscode-extension-tester": "^5.9.0"
       }
     },
     "webidl-conversions": {
@@ -12539,7 +12490,6 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
       "requires": {}
     },
     "xml": {

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "rimraf": "^5.0.1",
     "sinon": "^15.2.0",
     "typescript": "^5.1.6",
-    "vscode-uitests-tooling": "^4.0.3"
+    "vscode-uitests-tooling": "^4.0.5"
   },
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.6.1",


### PR DESCRIPTION
Brings latest `vscode-extension-tester` v5.9.0 with support for `VS Code 1.81.0`

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build
