### PR TITLE
FUSETOOLS2-2193 - Generate SBOM during GitHub workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -92,6 +92,15 @@ jobs:
       - name: vsce-package
         run: vsce package
 
+      - name: Generate SBOM
+        run: |
+          npm install --global @cyclonedx/cyclonedx-npm
+          cyclonedx-npm --omit dev --output-file manifest.json
+
+      - name: Store SBOM
+        uses: actions/upload-artifact@v3
+        with:
+          path: manifest.json
       - name: Store Camel Language Server log
         uses: actions/upload-artifact@v3
         if: failure() && matrix.os != 'windows-latest'


### PR DESCRIPTION
- this is a first iteration generating information only for the node modules, it is missing the embedded jar
- for future, will need to generate it on jenkins too and maybe upload on GitHub tag or other places

