### PR TITLE
FUSETOOLS2-2242: Collect ui-tests screenshoots and logs when cancelled

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -107,14 +107,24 @@ jobs:
 
       - name: Store UI test log
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-logs
           path: test-resources/settings/logs/*
 
       - name: Store UI Test Screenshots
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
           path: test-resources/screenshots/*.png

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -124,14 +124,24 @@ jobs:
 
       - name: Store UI test log
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-logs
           path: test-resources/settings/logs/*
 
       - name: Store UI Test Screenshots
         uses: actions/upload-artifact@v3
-        if: failure() && (steps.uiTest_Ubuntu.outcome == 'failure' || steps.uiTest_MacOS_Windows.outcome == 'failure')
+        if: |
+          (failure() || cancelled()) &&
+          (steps.uiTest_Ubuntu.outcome == 'failure' ||
+          steps.uiTest_MacOS_Windows.outcome == 'failure' ||
+          steps.uiTest_Ubuntu.outcome == 'cancelled' ||
+          steps.uiTest_MacOS_Windows.outcome == 'cancelled')
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-ui-test-screenshots
           path: test-resources/screenshots/*.png


### PR DESCRIPTION
Same as https://github.com/camel-tooling/camel-dap-client-vscode/pull/520

[1] [FUSETOOLS2-2242](https://issues.redhat.com/browse/FUSETOOLS2-2242)

LSP example with failed and cancelled jobs: https://github.com/camel-tooling/camel-lsp-client-vscode/actions/runs/6625828387