### PR TITLE
FUSETOOLS2-2269 - Provide a setting for jdk to use to launch the Language Server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Minimal version of VS Code to run this extension is 1.82.0
 - Update Camel Quarkus Catalog from 3.5.0 to 3.6.0
 - Provide command to create a Camel route from an OpenAPI file
+- Provide the setting `camel.ls.java.home` to configure the JDK used to start the Camel Language Server. It was previously relying on the deprecated `java.home` provided by VS Code Java.
 
 ## 0.13.0
 

--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,7 @@ For detailed information about Apache Camel supported features, see the [Apache 
 
 ### Requirements
 
-**Java 17+** is currently required to launch the [Apache Camel Language Server](https://github.com/camel-tooling/camel-language-server). The `java.home` VS Code preferences can be used to use a different version of JDK than the default one installed on the machine.
+**Java 17+** is currently required to launch the [Apache Camel Language Server](https://github.com/camel-tooling/camel-language-server). The `camel.ls.java.home` VS Code preferences can be used to use a different version of JDK than the default one installed on the machine.
 
 ⚠️ For some features, [JBang](https://www.jbang.dev/documentation/guide/latest/index.html) must be available on a system command-line.
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,15 @@
           "type": "string",
           "markdownDescription": "Apache Camel JBang version used for internal VS Code JBang commands execution. Camel JBang requirements can differ between versions, it is recommended to use `default` version to ensure all extension features work properly.\n\n**Note**: This change will affect only commands provided by Language Support for Apache Camel extension.",
           "default": "4.2.0"
+        },
+        "camel.ls.java.home": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Specifies the folder path to the JDK (17 or more recent) used to launch the Camel Language Server.\n\nOn Windows, backslashes must be escaped, i.e.\n\"camel.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk17.0_3\"",
+          "scope": "machine-overridable"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: ExtensionContext) {
 	const camelLanguageServerPath = context.asAbsolutePath(path.join('jars','language-server.jar'));
 	console.log(camelLanguageServerPath);
 
-	const requirementsData = await computeRequirementsData(context);
+	const requirementsData = await computeRequirementsData();
 
 	const serverOptions: Executable = {
 		command: retrieveJavaExecutable(requirementsData),
@@ -150,9 +150,9 @@ export async function deactivate() {
 	}
 }
 
-async function computeRequirementsData(context: ExtensionContext) {
+async function computeRequirementsData() {
 	try {
-		return await requirements.resolveRequirements(context);
+		return await requirements.resolveRequirements();
 	} catch (error) {
 		// show error
 		const selection = await window.showErrorMessage(error.message, error.label);

--- a/src/requirements/requirements.ts
+++ b/src/requirements/requirements.ts
@@ -2,7 +2,7 @@
 
 /* Mostly duplicated from VS Code Java */
 
-import { Uri, env, ExtensionContext } from 'vscode';
+import { Uri, env } from 'vscode';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as expandHomeDir from 'expand-home-dir';
@@ -25,11 +25,11 @@ export interface RequirementsData {
  * if any of the requirements fails to resolve.
  *
  */
-export async function resolveRequirements(context: ExtensionContext): Promise<RequirementsData> {
+export async function resolveRequirements(): Promise<RequirementsData> {
     return new Promise(async function (resolve, reject) {
         let source: string;
         let javaVersion = 0;
-        let javaHome = await checkJavaPreferences(context);
+        let javaHome = await checkJavaPreferences();
         if (javaHome) {
             // java.home explictly specified
             source = `java.home variable defined in ${env.appName} settings`;
@@ -58,7 +58,7 @@ export async function resolveRequirements(context: ExtensionContext): Promise<Re
         }
 
         if (javaVersion < REQUIRED_JRE_VERSION) {
-            openJDKDownload(reject, `Java ${REQUIRED_JRE_VERSION} or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)`);
+            openJDKDownload(reject, `Java ${REQUIRED_JRE_VERSION} or more recent is required to run the Language Support for Camel extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)`);
         }
 
         resolve({ java_home: javaHome, java_version: javaVersion });

--- a/src/requirements/settings.ts
+++ b/src/requirements/settings.ts
@@ -1,83 +1,13 @@
 'use strict';
 
 /* Mostly duplicated from VS Code Java */
+import {  workspace } from 'vscode';
 
-import * as path from 'path';
-import { window, workspace, ConfigurationTarget, env, ExtensionContext } from 'vscode';
-import { getJavaConfiguration } from './utils';
-
-export const IS_WORKSPACE_JDK_ALLOWED = 'java.ls.isJdkAllowed';
-export const IS_WORKSPACE_VMARGS_ALLOWED = 'java.ls.isVmargsAllowed';
-
-
-export async function checkJavaPreferences(context: ExtensionContext) {
-	const allow = 'Allow';
-	const disallow = 'Disallow';
-	let javaHome = workspace.getConfiguration().inspect<string>('java.home').workspaceValue;
-	let isVerified = javaHome === undefined || javaHome === null;
-	if (isVerified) {
-		javaHome = getJavaConfiguration().get('home');
-	}
-	const key = getKey(IS_WORKSPACE_JDK_ALLOWED, context.storagePath, javaHome);
-	const globalState = context.globalState;
-	if (!isVerified) {
-		isVerified = globalState.get(key);
-		if (isVerified === undefined) {
-			await window.showErrorMessage(`Security Warning! Do you allow this workspace to set the java.home variable? \n java.home: ${javaHome}`, disallow, allow).then(async selection => {
-				if (selection === allow) {
-					await globalState.update(key, true);
-				} else if (selection === disallow) {
-					await globalState.update(key, false);
-					await workspace.getConfiguration().update('java.home', undefined, ConfigurationTarget.Workspace);
-				}
-			});
-			isVerified = globalState.get(key);
-		}
-	}
-	const vmargs = workspace.getConfiguration().inspect('java.jdt.ls.vmargs').workspaceValue;
-	if (vmargs !== undefined) {
-		const agentFlag = getJavaagentFlag(vmargs);
-		if (agentFlag !== null) {
-			const keyVmargs = getKey(IS_WORKSPACE_VMARGS_ALLOWED, context.storagePath, vmargs);
-			const vmargsVerified = globalState.get(keyVmargs);
-			if (vmargsVerified === undefined || vmargsVerified === null) {
-				await window.showErrorMessage(`Security Warning! The java.jdt.ls.vmargs variable defined in ${env.appName} settings includes the (${agentFlag}) javagent preference. Do you allow it to be used?`, disallow, allow).then(async selection => {
-					if (selection === allow) {
-						await globalState.update(keyVmargs, true);
-					} else if (selection === disallow) {
-						await globalState.update(keyVmargs, false);
-						await workspace.getConfiguration().update('java.jdt.ls.vmargs', undefined, ConfigurationTarget.Workspace);
-					}
-				});
-			}
-		}
-	}
-	if (isVerified) {
+export async function checkJavaPreferences() {
+	const javaHome = workspace.getConfiguration().inspect<string>('camel.ls.java.home').workspaceValue;
+	if (javaHome !== null && javaHome !== undefined) {
 		return javaHome;
 	} else {
-		return workspace.getConfiguration().inspect<string>('java.home').globalValue;
+		return workspace.getConfiguration().inspect<string>('camel.ls.java.home').globalValue;
 	}
-}
-
-export function getKey(prefix, storagePath, value) {
-	const workspacePath = path.resolve(storagePath + '/jdt_ws');
-	if (workspace.name !== undefined) {
-		return `${prefix}::${workspacePath}::${value}`;
-	}
-	else {
-		return `${prefix}::${value}`;
-	}
-}
-
-export function getJavaagentFlag(vmargs) {
-	const javaagent = '-javaagent:';
-	const args = vmargs.split(' ');
-	let agentFlag = null;
-	for (const arg of args) {
-		if (arg.startsWith(javaagent)) {
-			agentFlag = arg.substring(javaagent.length);
-			break;
-		}
-	}
-	return agentFlag;
 }


### PR DESCRIPTION
it was previously relying on `java.home` from VS Code Java, which has been deprecated and now removed

![image](https://github.com/camel-tooling/camel-lsp-client-vscode/assets/1105127/ea975967-37da-41e6-9940-90184654d598)



