### PR TITLE
Update Camel Quarkus Catalog from 3.6.0 to 3.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.16.0
 
+- Update Camel Quarkus Catalog from 3.6.0 to 3.7.0
+
 ## 0.15.0
 
 - Provide command to create a Kamelet with YAML DSL


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-language-server/pull/1061