### PR TITLE
FUSETOOLS2-2308 - Fix launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceRoot}",
-				"--extensionTestsPath=${workspaceRoot}/out/src/test",
+				"--extensionTestsPath=${workspaceRoot}/out/src/test/suite/index",
 				"${workspaceRoot}/test Fixture with speci@l chars" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,


### PR DESCRIPTION
the extensionTestsPath must point to the index file as it is done in the runTests class

for reference
https://code.visualstudio.com/api/working-with-extensions/testing-extension#advanced-setup-your-own-runner

Note: will surely need to report similar change in all of our extensions

