### PR TITLE
Fix regression of extension not activating with `Cannot find module

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.19.0
 
+- Fix regression of extension not activating with `Cannot find module 'expand-home-dir'` error
+
 ## 0.18.0
 
 - Update default Camel version used for Camel JBang from 4.4.0 to 4.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "chai": "^4.3.10",
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
-        "expand-home-dir": "^0.0.3",
         "glob": "^10.3.12",
         "mocha": "^10.4.0",
         "mocha-jenkins-reporter": "^0.4.8",
@@ -3577,8 +3576,7 @@
     "node_modules/expand-home-dir": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
-      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA==",
-      "dev": true
+      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
     },
     "node_modules/expand-template": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -270,7 +270,6 @@
     "chai": "^4.3.10",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
-    "expand-home-dir": "^0.0.3",
     "glob": "^10.3.12",
     "mocha": "^10.4.0",
     "mocha-jenkins-reporter": "^0.4.8",


### PR DESCRIPTION
'expand-home-dir'` error

the `expand-home-dir` was defined as `devDependencies` on top of `dependencies`. it must be defined only in `dependencies`

