### PR TITLE
FUSETOOLS2-2396: Adds command to transform multiple files with existing routes to Yaml DSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,11 @@
         "command": "camel.jbang.transform.routes.in.folder.yaml",
         "title": "Transform any Camel Route in a specified folder to YAML DSL",
         "category": "Camel"
+      },
+      {
+        "command": "camel.jbang.transform.routes.in.files.yaml",
+        "title": "Transform Camel Routes in multiple files to YAML DSL",
+        "category": "Camel"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -229,6 +229,11 @@
         "title": "Transform a Camel Route to YAML DSL",
         "category": "Camel",
         "enablement": "resourceFilename =~ /\\.(java|xml|yaml)$/"
+      },
+      {
+        "command": "camel.jbang.transform.routes.in.folder.yaml",
+        "title": "Transform any Camel Route in a specified folder to YAML DSL",
+        "category": "Camel"
       }
     ],
     "menus": {

--- a/src/commands/AbstractTransformCamelRouteCommand.ts
+++ b/src/commands/AbstractTransformCamelRouteCommand.ts
@@ -54,4 +54,19 @@ export abstract class AbstractTransformCamelRouteCommand {
 		}
 		return Uri.parse('');
 	}
+
+	protected async showDialogToPickFiles(): Promise<Uri[]> {
+		const selectedFiles = await window.showOpenDialog(
+			{
+				canSelectMany: true,
+				canSelectFolders: false,
+				canSelectFiles: true,
+				openLabel: 'Select',
+				title: 'Select files to be transformed'
+			});
+		if (selectedFiles !== undefined) {
+			return selectedFiles;
+		}
+		return [Uri.parse('')];
+	}
 }

--- a/src/commands/AbstractTransformCamelRouteCommand.ts
+++ b/src/commands/AbstractTransformCamelRouteCommand.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { Uri, WorkspaceFolder, window, workspace } from "vscode";
+
+export abstract class AbstractTransformCamelRouteCommand {
+
+	protected workspaceFolder: WorkspaceFolder | undefined;
+
+	constructor() {
+		this.workspaceFolder = this.getWorkspaceFolder();
+	}
+
+	/**
+	 * Resolves first opened folder in vscode existing workspace
+	 *
+	 * @returns WorkspaceFolder object
+	 */
+	private getWorkspaceFolder(): WorkspaceFolder | undefined {
+		let workspaceFolder: WorkspaceFolder | undefined;
+		if (workspace.workspaceFolders) {
+			// default to root workspace folder
+			workspaceFolder = workspace.workspaceFolders[0];
+		}
+		return workspaceFolder;
+	}
+
+	protected async showDialogToPickFolder(isOutputFolder: boolean): Promise<Uri> {
+		const selectedFolders = await window.showOpenDialog(
+			{
+				canSelectMany: false,
+				canSelectFolders: true,
+				canSelectFiles: false,
+				openLabel: 'Select',
+				title: isOutputFolder ? 'Select a folder to output the transformed routes' : 'Select a folder to run the tranform command in'
+			});
+		if (selectedFolders !== undefined) {
+			return selectedFolders[0];
+		}
+		return Uri.parse('');
+	}
+}

--- a/src/commands/TransformCamelRouteCommand.ts
+++ b/src/commands/TransformCamelRouteCommand.ts
@@ -18,20 +18,16 @@
 
 import * as path from 'path';
 import validFilename from 'valid-filename';
-import { commands, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { commands, Uri, window } from 'vscode';
 import { CamelTransformRouteToYAMLJBangTask } from '../tasks/CamelTransformRouteToYAMLJBangTask';
+import { AbstractTransformCamelRouteCommand } from './AbstractTransformCamelRouteCommand';
 
 
-export class TransformCamelRouteToYAMLCommand {
+export class TransformCamelRouteToYAMLCommand extends AbstractTransformCamelRouteCommand{
 
-	public static ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML = 'camel.jbang.transform.route.yaml';
+	public static readonly ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML = 'camel.jbang.transform.route.yaml';
 
-	protected workspaceFolder: WorkspaceFolder | undefined;
 	protected fileNameInputPrompt = 'Please provide a name for the new transformed Camel Route.';
-
-	constructor() {
-		this.workspaceFolder = this.getWorkspaceFolder();
-	}
 
 	public async create(): Promise<void> {
 
@@ -40,7 +36,7 @@ export class TransformCamelRouteToYAMLCommand {
 			const currentOpenedFileDir = path.parse(currentOpenedFileUri.fsPath).dir;
 			const currentOpenedFileName = path.parse(currentOpenedFileUri.fsPath).name;
 			const transformedRouteFileName = await this.showInputBoxForFileName(currentOpenedFileName + '.yaml');
-		
+
 			if (transformedRouteFileName) {
 				const transformedRouteFilePath = path.join(currentOpenedFileDir, transformedRouteFileName);
 				if (this.workspaceFolder){
@@ -49,20 +45,6 @@ export class TransformCamelRouteToYAMLCommand {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Resolves first opened folder in vscode existing workspace
-	 *
-	 * @returns WorkspaceFolder object
-	 */
-	private getWorkspaceFolder(): WorkspaceFolder | undefined {
-		let workspaceFolder: WorkspaceFolder | undefined;
-		if (workspace.workspaceFolders) {
-			// default to root workspace folder
-			workspaceFolder = workspace.workspaceFolders[0];
-		}
-		return workspaceFolder;
 	}
 
 	protected async showInputBoxForFileName(placeHolder: string): Promise<string> {

--- a/src/commands/TransformCamelRoutesInFolderCommand.ts
+++ b/src/commands/TransformCamelRoutesInFolderCommand.ts
@@ -16,15 +16,22 @@
  */
 'use strict';
 
-import { TaskScope, WorkspaceFolder } from "vscode";
-import { CamelJBangTask } from "./CamelJBangTask";
-import { CamelJBang } from "../requirements/CamelJBang";
+import { CamelTransformRoutesInFolderToYAMLJBangTask } from '../tasks/CamelTransformRoutesInFolderToYAMLJBangTask';
+import { AbstractTransformCamelRouteCommand } from './AbstractTransformCamelRouteCommand';
 
-export class CamelTransformRouteToYAMLJBangTask extends CamelJBangTask {
+export class TransformCamelRoutesInFolderToYAMLCommand extends AbstractTransformCamelRouteCommand{
 
-	constructor(scope: WorkspaceFolder | TaskScope.Workspace, sourcePath: string, outputPath: string) {
-		super(scope,
-			'Transform a Camel Route to YAML DSL',
-			new CamelJBang().transformSingleRoute(sourcePath, 'yaml', outputPath));
+	public static readonly ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML = 'camel.jbang.transform.routes.in.folder.yaml';
+
+	public async create(): Promise<void> {
+
+		const sourceFolder = await this.showDialogToPickFolder(false);
+		const destinationFolder = await this.showDialogToPickFolder(true);
+
+		if (sourceFolder && destinationFolder && this.workspaceFolder) {
+			await new CamelTransformRoutesInFolderToYAMLJBangTask(this.workspaceFolder, sourceFolder.fsPath, destinationFolder.fsPath).execute();
+		}
+
 	}
+
 }

--- a/src/commands/TransformCamelRoutesInMultipleFilesCommand.ts
+++ b/src/commands/TransformCamelRoutesInMultipleFilesCommand.ts
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { CamelTransformRoutesInMultipleFilesToYAMLJBangTask } from '../tasks/CamelTransformRoutesInMultipleFilesToYAMLJBangTask';
+import { AbstractTransformCamelRouteCommand } from './AbstractTransformCamelRouteCommand';
+
+export class TransformCamelRoutesInMultipleFilesToYAMLCommand extends AbstractTransformCamelRouteCommand {
+
+	public static readonly ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_MULTIPLES_FILES_TO_YAML = 'camel.jbang.transform.routes.in.files.yaml';
+
+	public async create(): Promise<void> {
+
+		const sourceFiles = await this.showDialogToPickFiles();
+		const destinationFolder = await this.showDialogToPickFolder(true);
+
+		if (sourceFiles && destinationFolder && this.workspaceFolder) {
+			await new CamelTransformRoutesInMultipleFilesToYAMLJBangTask(
+				this.workspaceFolder,
+				sourceFiles.map(file => file.fsPath),
+				destinationFolder.fsPath).execute();
+		}
+
+	}
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,20 +18,21 @@
 
 import { TelemetryEvent, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry';
 import * as path from 'path';
-import { workspace, ExtensionContext, window, StatusBarAlignment, commands, TextEditor, languages, StatusBarItem } from 'vscode';
-import { LanguageClientOptions, DidChangeConfigurationNotification } from 'vscode-languageclient';
-import { LanguageClient, Executable } from 'vscode-languageclient/node';
+import { ExtensionContext, StatusBarAlignment, StatusBarItem, TextEditor, commands, languages, window, workspace } from 'vscode';
+import { DidChangeConfigurationNotification, LanguageClientOptions } from 'vscode-languageclient';
+import { Executable, LanguageClient } from 'vscode-languageclient/node';
+import * as telemetry from './Telemetry';
+import { NewCamelFileCommand } from './commands/NewCamelFileCommand';
+import { NewCamelKameletCommand } from './commands/NewCamelKameletCommand';
+import { NewCamelPipeCommand } from './commands/NewCamelPipeCommand';
+import { NewCamelQuarkusProjectCommand } from './commands/NewCamelQuarkusProjectCommand';
 import { NewCamelRouteCommand } from './commands/NewCamelRouteCommand';
+import { NewCamelRouteFromOpenAPICommand } from './commands/NewCamelRouteFromOpenAPICommand';
+import { NewCamelSpringBootProjectCommand } from './commands/NewCamelSpringBootProjectCommand';
+import { TransformCamelRouteToYAMLCommand } from './commands/TransformCamelRouteCommand';
+import { TransformCamelRoutesInFolderToYAMLCommand } from './commands/TransformCamelRoutesInFolderCommand';
 import { retrieveJavaExecutable } from './requirements/JavaManager';
 import * as requirements from './requirements/requirements';
-import * as telemetry from './Telemetry';
-import { NewCamelQuarkusProjectCommand } from './commands/NewCamelQuarkusProjectCommand';
-import { NewCamelSpringBootProjectCommand } from './commands/NewCamelSpringBootProjectCommand';
-import { NewCamelRouteFromOpenAPICommand } from './commands/NewCamelRouteFromOpenAPICommand';
-import { NewCamelKameletCommand } from './commands/NewCamelKameletCommand';
-import { NewCamelFileCommand } from './commands/NewCamelFileCommand';
-import { NewCamelPipeCommand } from './commands/NewCamelPipeCommand';
-import { TransformCamelRouteToYAMLCommand } from './commands/TransformCamelRouteCommand';
 
 const LANGUAGE_CLIENT_ID = 'LANGUAGE_ID_APACHE_CAMEL';
 const SETTINGS_TOP_LEVEL_KEY_CAMEL = 'camel';
@@ -164,7 +165,10 @@ export async function activate(context: ExtensionContext) {
 		await new TransformCamelRouteToYAMLCommand().create();
 		await sendCommandTrackingEvent(TransformCamelRouteToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML);
 	}));
-
+	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML, async () => {
+		await new TransformCamelRoutesInFolderToYAMLCommand().create();
+		await sendCommandTrackingEvent(TransformCamelRoutesInFolderToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML);
+	}));
 	context.subscriptions.push(commands.registerCommand(NewCamelFileCommand.ID_COMMAND_CAMEL_NEW_FILE, async () => {
 		await new NewCamelFileCommand().create();
 		await sendCommandTrackingEvent(NewCamelFileCommand.ID_COMMAND_CAMEL_NEW_FILE);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { NewCamelRouteFromOpenAPICommand } from './commands/NewCamelRouteFromOpe
 import { NewCamelSpringBootProjectCommand } from './commands/NewCamelSpringBootProjectCommand';
 import { TransformCamelRouteToYAMLCommand } from './commands/TransformCamelRouteCommand';
 import { TransformCamelRoutesInFolderToYAMLCommand } from './commands/TransformCamelRoutesInFolderCommand';
+import { TransformCamelRoutesInMultipleFilesToYAMLCommand } from './commands/TransformCamelRoutesInMultipleFilesCommand';
 import { retrieveJavaExecutable } from './requirements/JavaManager';
 import * as requirements from './requirements/requirements';
 
@@ -168,6 +169,10 @@ export async function activate(context: ExtensionContext) {
 	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML, async () => {
 		await new TransformCamelRoutesInFolderToYAMLCommand().create();
 		await sendCommandTrackingEvent(TransformCamelRoutesInFolderToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML);
+	}));
+	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInMultipleFilesToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_MULTIPLES_FILES_TO_YAML, async () => {
+		await new TransformCamelRoutesInMultipleFilesToYAMLCommand().create();
+		await sendCommandTrackingEvent(TransformCamelRoutesInMultipleFilesToYAMLCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_MULTIPLES_FILES_TO_YAML);
 	}));
 	context.subscriptions.push(commands.registerCommand(NewCamelFileCommand.ID_COMMAND_CAMEL_NEW_FILE, async () => {
 		await new NewCamelFileCommand().create();

--- a/src/requirements/CamelJBang.ts
+++ b/src/requirements/CamelJBang.ts
@@ -17,6 +17,7 @@
 'use strict';
 
 import { ShellExecution, workspace } from "vscode";
+import path from 'path';
 
 /**
  * Camel JBang class which allows shell execution of different jbang cli commands
@@ -44,22 +45,34 @@ export class CamelJBang {
 	public generateRest(routefile: string, openApiFile: string) {
 		return new ShellExecution('jbang',
 			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
-			'camel@apache/camel',
-			'generate',
-			'rest',
-			`'--input=${openApiFile}'`,
-			`'--output=${routefile}'`,
-			'--routes']);
+				'camel@apache/camel',
+				'generate',
+				'rest',
+				`'--input=${openApiFile}'`,
+				`'--output=${routefile}'`,
+				'--routes']);
 	}
 
-	public transformRoute(sourceFile: string, format: string, outputFile: string) {
+	public transformSingleRoute(sourcePath: string, format: string, outputPath: string) {
 		return new ShellExecution('jbang',
-		[`'-Dcamel.jbang.version=${this.camelVersion}'`,
-			'camel@apache/camel',
-			'transform',
-			'route',
-			`'${sourceFile}'`,
-			`'--format=${format}'`,
-			`'--output=${outputFile}'`,]);
+			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
+				'camel@apache/camel',
+				'transform',
+				'route',
+				`'${sourcePath}'`,
+				`'--format=${format}'`,
+				`'--output=${outputPath}'`,]);
 	}
+
+	public transformRoutesInFolder(sourcePath: string, format: string, outputPath: string,) {
+		return new ShellExecution('jbang',
+			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
+				'camel@apache/camel',
+				'transform',
+				'route',
+				`'${sourcePath}'${path.sep}*`,
+				`'--format=${format}'`,
+				`'--output=${outputPath}'`,]);
+	}
+
 }

--- a/src/requirements/CamelJBang.ts
+++ b/src/requirements/CamelJBang.ts
@@ -75,4 +75,18 @@ export class CamelJBang {
 				`'--output=${outputPath}'`,]);
 	}
 
+	public transformRoutesInMultipleFiles(sourcePaths: string[], format: string, outputPath: string) {
+		const joinedSourcePaths = sourcePaths.map(
+			sourcePath => `'${sourcePath}'`
+		).join(' ');
+		return new ShellExecution('jbang',
+			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
+				'camel@apache/camel',
+				'transform',
+				'route',
+				joinedSourcePaths,
+			`'--format=${format}'`,
+			`'--output=${outputPath}'`,]);
+	}
+
 }

--- a/src/tasks/CamelTransformRoutesInFolderToYAMLJBangTask.ts
+++ b/src/tasks/CamelTransformRoutesInFolderToYAMLJBangTask.ts
@@ -20,11 +20,11 @@ import { TaskScope, WorkspaceFolder } from "vscode";
 import { CamelJBangTask } from "./CamelJBangTask";
 import { CamelJBang } from "../requirements/CamelJBang";
 
-export class CamelTransformRouteToYAMLJBangTask extends CamelJBangTask {
+export class CamelTransformRoutesInFolderToYAMLJBangTask extends CamelJBangTask {
 
 	constructor(scope: WorkspaceFolder | TaskScope.Workspace, sourcePath: string, outputPath: string) {
 		super(scope,
-			'Transform a Camel Route to YAML DSL',
-			new CamelJBang().transformSingleRoute(sourcePath, 'yaml', outputPath));
+			'Transform any Camel Route in a specified folder to YAML DSL',
+			new CamelJBang().transformRoutesInFolder(sourcePath, 'yaml', outputPath));
 	}
 }

--- a/src/tasks/CamelTransformRoutesInMultipleFilesToYAMLJBangTask.ts
+++ b/src/tasks/CamelTransformRoutesInMultipleFilesToYAMLJBangTask.ts
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { TaskScope, WorkspaceFolder } from "vscode";
+import { CamelJBangTask } from "./CamelJBangTask";
+import { CamelJBang } from "../requirements/CamelJBang";
+
+export class CamelTransformRoutesInMultipleFilesToYAMLJBangTask extends CamelJBangTask {
+
+	constructor(scope: WorkspaceFolder | TaskScope.Workspace, sourcePaths: string[], outputPath: string) {
+		super(scope,
+			'Transform Camel Routes in multiple files to YAML DSL',
+			new CamelJBang().transformRoutesInMultipleFiles(sourcePaths, 'yaml', outputPath));
+	}
+}


### PR DESCRIPTION
Adds a command to allow the user to select source files and if they are
camel routes they will be transformed to equivalent Yaml routes.

Signed-off-by: Marcelo Henrique Diniz de Araujo <mdinizde@redhat.com>