### PR TITLE
FUSETOOLS2-2411: Fix transform route command filename validation

### DIFF
--- a/src/commands/AbstractCamelCommand.ts
+++ b/src/commands/AbstractCamelCommand.ts
@@ -16,7 +16,10 @@
  */
 'use strict';
 
+import * as fs from 'fs';
 import { WorkspaceFolder, workspace } from "vscode";
+import validFilename = require("valid-filename");
+import path = require("path");
 
 export interface CamelRouteDSL {
 	language: string;
@@ -60,5 +63,70 @@ export abstract class AbstractCamelCommand {
 		}
 		return workspaceFolder;
 	}
+
+	/**
+	 * Camel file name validation
+	 *  - no empty name
+	 *  - name without extension
+	 *  - file already exists check
+	 *  - name cannot contains eg. special characters
+	 *  - Java pattern naming convention \b[A-Z][a-zA-Z_$0-9]*
+	 *
+	 * @param name
+	 * @returns string | undefined
+	 */
+		public validateCamelFileName(name: string, folderPath?: string): string | undefined {
+			if (!name) {
+				return 'Please provide a name for the new file (without extension).';
+			}
+
+			if (name.includes('.')) {
+				return 'Please provide a name without the extension.';
+			}
+
+			if (!this.camelDSL) {
+				return 'Internal error: Camel DSL is undefined.'; // camelDSL can't be undefined
+			}
+
+			if (!this.workspaceFolder) {
+				return 'Internal error: Workspace folder is undefined.';
+			}
+
+			const newFilePotentialFullPath: string = this.computeFullPath(folderPath ?? this.workspaceFolder.uri.fsPath, this.getFullName(name, this.camelDSL.extension));
+			if (fs.existsSync(newFilePotentialFullPath)) {
+				return 'The file already exists. Please choose a different file name.';
+			}
+			if (!validFilename(name)) {
+				return 'The filename is invalid.';
+			}
+
+			const patternJavaNamingConvention = '\\b[A-Z][a-zA-Z_$0-9]*';
+			if ((this.camelDSL.language === 'Java') && (!name.match(patternJavaNamingConvention) || name.includes(' '))) {
+				return `The filename needs to follow the ${this.camelDSL.language} naming convention. I.e. ${patternJavaNamingConvention}`;
+			}
+			return undefined;
+		}
+
+		/**
+		 * Get the full file name for provided name and suffix
+		 *
+		 * @param name of the file
+		 * @param suffix of the file
+		 * @returns the full file name format [name.suffix] eg. foo.yaml
+		 */
+		protected getFullName(name: string, suffix: string): string {
+			return `${name}.${suffix}`;
+		}
+
+		/**
+		 * Resolves absolute path for the given workspace and file
+		 *
+		 * @param folderPath
+		 * @param file
+		 * @returns abosolute string Path
+		 */
+		protected computeFullPath(folderPath: string, file: string): string {
+			return path.join(folderPath, file);
+		}
 
 }

--- a/src/commands/AbstractNewCamelRouteCommand.ts
+++ b/src/commands/AbstractNewCamelRouteCommand.ts
@@ -16,13 +16,11 @@
  */
 'use strict';
 
-import { WorkspaceFolder, window } from "vscode";
-import * as fs from 'fs';
-import validFilename = require("valid-filename");
-import path = require("path");
+import { window } from "vscode";
+
 import { AbstractCamelCommand } from "./AbstractCamelCommand";
 
-export abstract class AbstractNewCamelRouteCommand extends AbstractCamelCommand{
+export abstract class AbstractNewCamelRouteCommand extends AbstractCamelCommand {
 
 	protected fileNameInputPrompt = 'Please provide a name for the new file (without extension).';
 
@@ -36,72 +34,6 @@ export abstract class AbstractNewCamelRouteCommand extends AbstractCamelCommand{
 		});
 
 		return input ?? '';
-	}
-
-	/**
-	 * Camel file name validation
-	 *  - no empty name
-	 *  - name without extension
-	 *  - file already exists check
-	 *  - name cannot contains eg. special characters
-	 *  - Java pattern naming convention \b[A-Z][a-zA-Z_$0-9]*
-	 *
-	 * @param name
-	 * @returns string | undefined
-	 */
-	public validateCamelFileName(name: string): string | undefined {
-		if (!name) {
-			return 'Please provide a name for the new file (without extension).';
-		}
-
-		if (name.includes('.')) {
-			return 'Please provide a name without the extension.';
-		}
-
-		if (!this.camelDSL) {
-			return 'Internal error: Camel DSL is undefined.'; // camelDSL can't be undefined
-		}
-
-		if (!this.workspaceFolder) {
-			return 'Internal error: Workspace folder is undefined.';
-		}
-
-		const newFilePotentialFullPath: string = this.computeFullPath(this.workspaceFolder, this.getFullName(name, this.camelDSL.extension));
-
-		if (fs.existsSync(newFilePotentialFullPath)) {
-			return 'The file already exists. Please choose a different file name.';
-		}
-		if (!validFilename(name)) {
-			return 'The filename is invalid.';
-		}
-
-		const patternJavaNamingConvention = '\\b[A-Z][a-zA-Z_$0-9]*';
-		if ((this.camelDSL.language === 'Java') && (!name.match(patternJavaNamingConvention) || name.includes(' '))) {
-			return `The filename needs to follow the ${this.camelDSL.language} naming convention. I.e. ${patternJavaNamingConvention}`;
-		}
-		return undefined;
-	}
-
-	/**
-	 * Get the full file name for provided name and suffix
-	 *
-	 * @param name of the file
-	 * @param suffix of the file
-	 * @returns the full file name format [name.suffix] eg. foo.yaml
-	 */
-	protected getFullName(name: string, suffix: string): string {
-		return `${name}.${suffix}`;
-	}
-
-	/**
-	 * Resolves absolute path for the given workspace and file
-	 *
-	 * @param workspaceFolder
-	 * @param file
-	 * @returns abosolute string Path
-	 */
-	protected computeFullPath(workspaceFolder: WorkspaceFolder, file: string): string {
-		return path.join(workspaceFolder.uri.fsPath, file);
 	}
 
 }

--- a/src/commands/NewCamelKameletCommand.ts
+++ b/src/commands/NewCamelKameletCommand.ts
@@ -35,7 +35,7 @@ export class NewCamelKameletCommand extends AbstractNewCamelRouteCommand {
 			const name = await this.showInputBoxForFileName();
 			if (name) {
 				const fileName = this.getKameletFullName(name, type, this.camelDSL.extension);
-				const filePath = this.computeFullPath(this.workspaceFolder, fileName);
+				const filePath = this.computeFullPath(this.workspaceFolder.uri.fsPath, fileName);
 
 				await new CamelInitJBangTask(this.workspaceFolder, fileName).execute();
 				await commands.executeCommand('vscode.open', Uri.file(filePath));

--- a/src/commands/NewCamelPipeCommand.ts
+++ b/src/commands/NewCamelPipeCommand.ts
@@ -29,7 +29,7 @@ export class NewCamelPipeCommand extends AbstractNewCamelRouteCommand {
 		const name = await this.showInputBoxForFileName();
 		if (name && this.camelDSL && this.workspaceFolder) {
 			const fileName = this.getPipeFullName(name, this.camelDSL.extension);
-			const filePath = this.computeFullPath(this.workspaceFolder, fileName);
+			const filePath = this.computeFullPath(this.workspaceFolder.uri.fsPath, fileName);
 
 			await new CamelBindJBangTask(this.workspaceFolder, fileName).execute();
 			await commands.executeCommand('vscode.open', Uri.file(filePath));

--- a/src/commands/NewCamelRouteCommand.ts
+++ b/src/commands/NewCamelRouteCommand.ts
@@ -30,7 +30,7 @@ export class NewCamelRouteCommand extends AbstractNewCamelRouteCommand {
 		const input = await this.showInputBoxForFileName();
 		if(input && this.camelDSL && this.workspaceFolder) {
 			const fileName = this.getFullName(input, this.camelDSL.extension);
-			const filePath = this.computeFullPath(this.workspaceFolder, fileName);
+			const filePath = this.computeFullPath(this.workspaceFolder.uri.fsPath, fileName);
 
 			await new CamelInitJBangTask(this.workspaceFolder, fileName).execute();
 			await commands.executeCommand('vscode.open', Uri.file(filePath));

--- a/src/commands/NewCamelRouteFromOpenAPICommand.ts
+++ b/src/commands/NewCamelRouteFromOpenAPICommand.ts
@@ -28,7 +28,7 @@ export class NewCamelRouteFromOpenAPICommand extends AbstractNewCamelRouteComman
 		const routeFileName = await this.showInputBoxForFileName();
 		if (routeFileName && this.camelDSL && this.workspaceFolder) {
 			const fileName = this.getFullName(routeFileName, this.camelDSL.extension);
-			const filePath = this.computeFullPath(this.workspaceFolder, fileName);
+			const filePath = this.computeFullPath(this.workspaceFolder.uri.fsPath, fileName);
 
 			const openAPIfilePath = await this.showDialogToPickOpenAPIFile();
 			if (openAPIfilePath) {

--- a/src/ui-test/tests/commands.transform.test.ts
+++ b/src/ui-test/tests/commands.transform.test.ts
@@ -53,7 +53,8 @@ describe('Transform Camel Routes to YAML using commands', function () {
 	routesToBeTransformed.forEach(function (route) {
 		describe('Camel Transform Routes', function () {
 
-			const FILENAME_CREATED_FROM_CAMEL_TRANSFORM: string = `transformedFrom${route.type}${route.fileExtension}`;
+			const INPUT_FILENAME: string = `transformedFrom${route.type}`;
+			const FILENAME_CREATED_FROM_CAMEL_TRANSFORM: string = `transformedFrom${route.type}.camel.yaml`;
 
 			after(async function () {
 				await deleteFile(FILENAME_CREATED_FROM_CAMEL_TRANSFORM, FOLDER_WITH_RESOURCES_FOR_TRANSFORM_COMMAND);
@@ -69,7 +70,7 @@ describe('Transform Camel Routes to YAML using commands', function () {
 				await driver.sleep(1000);
 
 				input = await InputBox.create(45000);
-				await input.setText(FILENAME_CREATED_FROM_CAMEL_TRANSFORM);
+				await input.setText(INPUT_FILENAME);
 				await input.confirm();
 
 				await waitUntilEditorIsOpened(driver, FILENAME_CREATED_FROM_CAMEL_TRANSFORM, 45000);


### PR DESCRIPTION
The "tranform route to YAML" command was accepting any filename as output. This was fixed by using the same logic in the "create new route" commands.
