### PR TITLE
Update default Camel JBang version to 4.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Use `.camel.yaml` as placeholder for output format for transforming Camel Routes
 - Update Kamelet Catalog from 4.6.0 to 4.7.0
 - Update default Camel Catalog version from 4.6.0 to 4.7.0
+- Update default Camel version used for Camel JBang from 4.6.0 to 4.7.0
 
 ## 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "camel.languageSupport.JBangVersion": {
           "type": "string",
           "markdownDescription": "Apache Camel JBang version used for internal VS Code JBang commands execution. Camel JBang requirements can differ between versions, it is recommended to use `default` version to ensure all extension features work properly.\n\n**Note**: This change will affect only commands provided by Language Support for Apache Camel extension.",
-          "default": "4.6.0"
+          "default": "4.7.0"
         },
         "camel.ls.java.home": {
           "type": [

--- a/src/requirements/CamelJBang.ts
+++ b/src/requirements/CamelJBang.ts
@@ -42,7 +42,7 @@ export class CamelJBang {
 		return new ShellExecution('jbang', [`'-Dcamel.jbang.version=${this.camelVersion}'`, 'camel@apache/camel', 'export', `--runtime=${runtime}`, `--gav=${gav}`]);
 	}
 
-	public generateRest(routefile: string, openApiFile: string) {
+	public generateRest(routefile: string, openApiFile: string): ShellExecution {
 		return new ShellExecution('jbang',
 			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
 				'camel@apache/camel',
@@ -89,4 +89,12 @@ export class CamelJBang {
 			`'--output=${outputPath}'`,]);
 	}
 
+	public add(plugin: string): ShellExecution {
+		return new ShellExecution('jbang',
+			[`'-Dcamel.jbang.version=${this.camelVersion}'`,
+				'camel@apache/camel',
+				'plugin',
+				'add',
+				plugin]);
+	}
 }

--- a/src/tasks/CamelAddPluginJBangTask.ts
+++ b/src/tasks/CamelAddPluginJBangTask.ts
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { TaskScope } from "vscode";
+import { CamelJBangTask } from "./CamelJBangTask";
+import { CamelJBang } from "../requirements/CamelJBang";
+
+export class CamelAddPluginJBangTask extends CamelJBangTask {
+
+	constructor(plugin: string) {
+		super(TaskScope.Workspace,
+			'Add required Camel JBang plugin',
+			new CamelJBang().add(plugin));
+	}
+}

--- a/src/ui-test/resources/camel_route_command/Java.java
+++ b/src/ui-test/resources/camel_route_command/Java.java
@@ -1,14 +1,10 @@
-// camel-k: language=java
-
 import org.apache.camel.builder.RouteBuilder;
 
 public class Java extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-
-        // Write your routes here, for example:
-        from("timer:java?period={{time:1000}}")
+        from("timer:java?period=1000")
             .setBody()
                 .simple("Hello Camel from ${routeId}")
             .log("${body}");

--- a/src/ui-test/resources/camel_route_command/XML.xml
+++ b/src/ui-test/resources/camel_route_command/XML.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- camel-k: language=xml -->
-
 <camel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://camel.apache.org/schema/spring"
         xsi:schemaLocation="
             http://camel.apache.org/schema/spring
             https://camel.apache.org/schema/spring/camel-spring.xsd">
 
-	<!-- Write your routes here, for example: -->
     <route>
-        <from uri="timer:xml?period={{time:1000}}"/>
+        <from uri="timer:xml?period=1000"/>
         <setBody>
             <simple>Hello Camel from ${routeId}</simple>
         </setBody>

--- a/src/ui-test/resources/camel_route_command/YAML.yaml
+++ b/src/ui-test/resources/camel_route_command/YAML.yaml
@@ -1,6 +1,3 @@
-# camel-k: language=yaml
-
-# Write your routes here, for example:
 - from:
     uri: "timer:yaml"
     parameters:

--- a/src/ui-test/resources/camel_transform_command/YAML.yaml
+++ b/src/ui-test/resources/camel_transform_command/YAML.yaml
@@ -1,11 +1,9 @@
-# camel-k: language=yaml
-
-# Write your routes here, for example:
-- from:
-    uri: "timer:yaml"
-    parameters:
-      period: "1000"
-    steps:
-      - setBody:
-          simple: "Hello Camel from ${routeId}"
-      - log: "${body}"
+- route:
+    from:
+      uri: timer:yaml?period=1000
+      steps:
+        - setBody:
+            simple:
+              expression: "Hello Camel from ${routeId}"
+        - log:
+            message: "${body}"


### PR DESCRIPTION
- The generated routes have slightly changed
- Camel route generation from OpenAPi spec has been moved to a specific
camel jbang plugin
https://camel.apache.org/manual/camel-4x-upgrade-guide-4_7.html#_camel_jbang