### PR TITLE
Use readonly for public static property

### DIFF
--- a/src/commands/NewCamelKameletCommand.ts
+++ b/src/commands/NewCamelKameletCommand.ts
@@ -23,7 +23,7 @@ import { CamelRouteDSL } from "./AbstractCamelCommand";
 
 export class NewCamelKameletCommand extends AbstractNewCamelRouteCommand {
 
-	public static ID_COMMAND_CAMEL_ROUTE_KAMELET_YAML = 'camel.jbang.routes.kamelet.yaml';
+	public static readonly ID_COMMAND_CAMEL_ROUTE_KAMELET_YAML = 'camel.jbang.routes.kamelet.yaml';
 
 	private kameletType: string = '';
 

--- a/src/commands/NewCamelQuarkusProjectCommand.ts
+++ b/src/commands/NewCamelQuarkusProjectCommand.ts
@@ -20,7 +20,7 @@ import { NewCamelProjectCommand } from "./NewCamelProjectCommand";
 
 export class NewCamelQuarkusProjectCommand extends NewCamelProjectCommand {
 
-	public static ID_COMMAND_CAMEL_QUARKUS_PROJECT = 'camel.jbang.project.quarkus.new';
+	public static readonly ID_COMMAND_CAMEL_QUARKUS_PROJECT = 'camel.jbang.project.quarkus.new';
 
 	getRuntime(): string {
 		return 'quarkus';

--- a/src/commands/NewCamelRouteCommand.ts
+++ b/src/commands/NewCamelRouteCommand.ts
@@ -23,9 +23,9 @@ import * as path from 'path';
 
 export class NewCamelRouteCommand extends AbstractNewCamelRouteCommand {
 
-	public static ID_COMMAND_CAMEL_ROUTE_JBANG_YAML = 'camel.jbang.routes.yaml';
-	public static ID_COMMAND_CAMEL_ROUTE_JBANG_JAVA = 'camel.jbang.routes.java';
-	public static ID_COMMAND_CAMEL_ROUTE_JBANG_XML = 'camel.jbang.routes.xml';
+	public static readonly ID_COMMAND_CAMEL_ROUTE_JBANG_YAML = 'camel.jbang.routes.yaml';
+	public static readonly ID_COMMAND_CAMEL_ROUTE_JBANG_JAVA = 'camel.jbang.routes.java';
+	public static readonly ID_COMMAND_CAMEL_ROUTE_JBANG_XML = 'camel.jbang.routes.xml';
 
 	public async create(targetFolder : Uri): Promise<void> {
 		const input = await this.showInputBoxForFileName(targetFolder ? targetFolder.fsPath : undefined);

--- a/src/commands/NewCamelRouteFromOpenAPICommand.ts
+++ b/src/commands/NewCamelRouteFromOpenAPICommand.ts
@@ -23,7 +23,7 @@ import { CamelAddPluginJBangTask } from "../tasks/CamelAddPluginJBangTask";
 
 export class NewCamelRouteFromOpenAPICommand extends AbstractNewCamelRouteCommand {
 
-	public static ID_COMMAND_CAMEL_ROUTE_FROM_OPEN_API_JBANG_YAML = 'camel.jbang.routes.yaml.fromopenapi';
+	public static readonly ID_COMMAND_CAMEL_ROUTE_FROM_OPEN_API_JBANG_YAML = 'camel.jbang.routes.yaml.fromopenapi';
 
 	public async create(): Promise<void> {
 		const routeFileName = await this.showInputBoxForFileName();

--- a/src/commands/NewCamelSpringBootProjectCommand.ts
+++ b/src/commands/NewCamelSpringBootProjectCommand.ts
@@ -20,7 +20,7 @@ import { NewCamelProjectCommand } from "./NewCamelProjectCommand";
 
 export class NewCamelSpringBootProjectCommand extends NewCamelProjectCommand {
 
-	public static ID_COMMAND_CAMEL_SPRINGBOOT_PROJECT = 'camel.jbang.project.springboot.new';
+	public static readonly ID_COMMAND_CAMEL_SPRINGBOOT_PROJECT = 'camel.jbang.project.springboot.new';
 
 	getRuntime(): string {
 		return 'spring-boot';


### PR DESCRIPTION
as recommended by Sonarlint
https://sonarcloud.io/organizations/camel-tooling/rules?open=typescript%3AS1444&rule_key=typescript%3AS1444

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build
