### PR TITLE
FUSETOOLS2-2458 - Provide contextual menu to transform routes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 1.6.0
 
+- Provide contextual menu to transform routes. In the `New Camel file` menu tranform the right clicked files or all the file in a clicked folder.
+
 ## 1.5.0
 
 - Provide completion for Camel component Maven dependency in pom.xml. Take care to have the correct runtime provider selected in Preferences.

--- a/package.json
+++ b/package.json
@@ -302,7 +302,28 @@
           "command": "camel.jbang.routes.yaml.fromopenapi",
           "group": "1_camel@5",
           "when": "workspaceFolderCount != 0"
+        },
+        {
+          "command": "camel.jbang.transform.route.yaml",
+          "group": "1_camel@6",
+          "when": "workspaceFolderCount != 0 && !explorerResourceIsFolder"
+        },
+        {
+          "command": "camel.jbang.transform.route.xml",
+          "group": "1_camel@7",
+          "when": "workspaceFolderCount != 0 && !explorerResourceIsFolder"
+        },
+        {
+          "command": "camel.jbang.transform.routes.in.folder.yaml",
+          "group": "1_camel@8",
+          "when": "workspaceFolderCount != 0 && explorerResourceIsFolder"
+        },
+        {
+          "command": "camel.jbang.transform.routes.in.folder.xml",
+          "group": "1_camel@9",
+          "when": "workspaceFolderCount != 0 && explorerResourceIsFolder"
         }
+
       ]
     },
     "submenus": [

--- a/src/commands/TransformCamelRoutesInFolderCommand.ts
+++ b/src/commands/TransformCamelRoutesInFolderCommand.ts
@@ -16,17 +16,24 @@
  */
 'use strict';
 
+import { FileType, Uri, workspace } from 'vscode';
 import { CamelTransformRoutesInFolderJBangTask } from '../tasks/CamelTransformRoutesInFolderJBangTask';
 import { AbstractTransformCamelRouteCommand } from './AbstractTransformCamelRouteCommand';
+import { isEqual } from 'lodash';
 
 export class TransformCamelRoutesInFolderCommand extends AbstractTransformCamelRouteCommand{
 
 	public static readonly ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML = 'camel.jbang.transform.routes.in.folder.yaml';
 	public static readonly ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_XML = 'camel.jbang.transform.routes.in.folder.xml';
 
-	public async create(): Promise<void> {
+	public async create(uri?: Uri): Promise<void> {
 
-		const sourceFolder = await this.showDialogToPickFolder(false);
+		// If an Uri was passed and it is a folder use it otherwise defaults to opening a dialog to select a soucer folder
+		let sourceFolder = uri;
+		if (!sourceFolder || !(await workspace.fs.stat(sourceFolder).then(stat => isEqual(stat.type,FileType.Directory)))) {
+			sourceFolder = await this.showDialogToPickFolder(false);
+		}
+
 		const destinationFolder = await this.showDialogToPickFolder(true);
 
 		if (sourceFolder && destinationFolder && this.workspaceFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,20 +162,20 @@ export async function activate(context: ExtensionContext) {
 		await new NewCamelSpringBootProjectCommand().create();
 		await sendCommandTrackingEvent(NewCamelSpringBootProjectCommand.ID_COMMAND_CAMEL_SPRINGBOOT_PROJECT);
 	}));
-	context.subscriptions.push(commands.registerCommand(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML, async () => {
-		await new TransformCamelRouteCommand('YAML').create();
+	context.subscriptions.push(commands.registerCommand(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML, async (uri: Uri) => {
+		await new TransformCamelRouteCommand('YAML').create(uri);
 		await sendCommandTrackingEvent(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_YAML);
 	}));
-	context.subscriptions.push(commands.registerCommand(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_XML, async () => {
-		await new TransformCamelRouteCommand('XML').create();
+	context.subscriptions.push(commands.registerCommand(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_XML, async (uri: Uri) => {
+		await new TransformCamelRouteCommand('XML').create(uri);
 		await sendCommandTrackingEvent(TransformCamelRouteCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTE_TO_XML);
 	}));
-	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML, async () => {
-		await new TransformCamelRoutesInFolderCommand('YAML').create();
+	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML, async (uri: Uri) => {
+		await new TransformCamelRoutesInFolderCommand('YAML').create(uri);
 		await sendCommandTrackingEvent(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_YAML);
 	}));
-	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_XML, async () => {
-		await new TransformCamelRoutesInFolderCommand('XML').create();
+	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_XML, async (uri: Uri) => {
+		await new TransformCamelRoutesInFolderCommand('XML').create(uri);
 		await sendCommandTrackingEvent(TransformCamelRoutesInFolderCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_FOLDER_TO_XML);
 	}));
 	context.subscriptions.push(commands.registerCommand(TransformCamelRoutesInMultipleFilesCommand.ID_COMMAND_CAMEL_JBANG_TRANSFORM_ROUTES_IN_MULTIPLES_FILES_TO_YAML, async () => {

--- a/src/ui-test/utils/testUtils.ts
+++ b/src/ui-test/utils/testUtils.ts
@@ -21,6 +21,8 @@ import {
 	By,
 	ComboSetting,
 	ContentAssistItem,
+	ContextMenu,
+	ContextMenuItem,
 	DefaultTreeSection,
 	EditorView,
 	InputBox,
@@ -31,6 +33,7 @@ import {
 	TerminalView,
 	TextEditor,
 	TextSetting,
+	ViewItem,
 	VSBrowser,
 	WebDriver,
 	Workbench
@@ -114,6 +117,10 @@ export const CATALOG_VERSION_UI = 'Camel catalog version';
 // Specific workspace for creating project with command.
 export const SPECIFIC_WORKSPACE_NAME: string = 'create-camel-project-workspace';
 export const SPECIFIC_WORKSPACE_PATH: string = path.join(RESOURCES, SPECIFIC_WORKSPACE_NAME);
+
+//Context menu labels.
+export const NEW_CAMEL_FILE_LABEL = 'New Camel File';
+export const TRANSFORM_CAMEL_ROUTE_YAML_DSL_LABEL = 'Transform a Camel Route to YAML DSL';
 
 // Other constant items
 export const LSP_STATUS_BAR_MESSAGE = 'Camel LS';
@@ -593,4 +600,31 @@ export async function initNewCamelFile(type: string, name: string, kamelet: stri
 	input = await InputBox.create(5_000);
 	await input.setText(name);
 	await input.confirm();
+}
+
+/**
+ * Opens the context menu for a given route in the sidebar.
+ * @param route The route for which the context menu should be opened.
+ * @returns A promise that resolves to the opened ContextMenu.
+ */
+export async function openContextMenu(route: string): Promise<ContextMenu> {
+    const item = await (await new SideBarView().getContent().getSection('explorer')).findItem(route) as ViewItem;
+    const menu = await item.openContextMenu();
+    return menu;
+}
+
+/**
+ * Selects a specific command from a given context menu.
+ * @param command The command to select from the context menu.
+ * @param menu The ContextMenu instance from which to select the command.
+ * @returns A promise that resolves once the command is selected.
+ * @throws An error if the specified command is not found in the context menu.
+ */
+export async function selectContextMenuItem(command: string, menu: ContextMenu): Promise<void> {
+    const button = await menu.getItem(command);
+    if (button instanceof ContextMenuItem) {
+        await button.select();
+    } else {
+        throw new Error(`Button ${command} not found in context menu`);
+    }
 }


### PR DESCRIPTION
- Add tranform commands to the "New Camel file" contextual menu
- Right clicking a file provides de ability to transform it to XML/Yaml DSLs
- Right clicking a folder tries to transform all routes in it to XML/Yaml DSLs