### PR TITLE
FUSETOOLS2-2113 - Allows selection of folder when creating projects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0
 
+- Provide folder selection when using `Create Camel Quarkus/SpringBoot Project` command
+
 ## 1.7.0
 
 - Update Kamelet Catalog from 4.8.0 to 4.8.1

--- a/package.json
+++ b/package.json
@@ -197,14 +197,12 @@
       {
         "command": "camel.jbang.project.quarkus.new",
         "title": "Create a Camel Quarkus project",
-        "category": "Camel",
-        "enablement": "workspaceFolderCount != 0"
+        "category": "Camel"
       },
       {
         "command": "camel.jbang.project.springboot.new",
         "title": "Create a Camel on SpringBoot project",
-        "category": "Camel",
-        "enablement": "workspaceFolderCount != 0"
+        "category": "Camel"
       },
       {
         "command": "camel.jbang.routes.yaml.fromopenapi",

--- a/src/requirements/utils.ts
+++ b/src/requirements/utils.ts
@@ -1,9 +1,44 @@
 'use strict';
 
 /* Mostly duplicated from VS Code Java */
-
+import path from 'path';
 import { workspace, WorkspaceConfiguration } from 'vscode';
 
 export function getJavaConfiguration(): WorkspaceConfiguration {
 	return workspace.getConfiguration('java');
+}
+
+/**
+ * If there are any folder in the current workspace gets the path to the first one.
+ *
+ * @returns string represent the fsPath of the first folder in the current opened workspace, undefined otherwise.
+ */
+export function getCurrentWorkingDirectory(): string | undefined {
+	const workspaceFolders = workspace.workspaceFolders;
+	if (workspaceFolders && workspaceFolders.length > 0) {
+		// Return the first workspace folder
+		return workspaceFolders[0].uri.fsPath;
+	}
+	return undefined;
+}
+
+/**
+ * Compare two given paths to see if they are equal. Normalizes the string and takes into acount case sentive OSes.
+ *
+ * @param path1 string representing the first path to be compared
+ * @param path2 string representing t,he second path to be compared
+ * @returns `true` if paths are equal `false` otherwise.
+ */
+export function arePathsEqual(path1: string, path2: string): boolean {
+	// Normalize both paths
+	const normalizedPath1 = path.normalize(path1);
+	const normalizedPath2 = path.normalize(path2);
+
+	// On Windows and macOS, perform case-insensitive comparison
+	if (process.platform === 'win32' || process.platform === 'darwin') {
+		return normalizedPath1.toLowerCase() === normalizedPath2.toLowerCase();
+	}
+
+	// On Linux (and other case-sensitive systems), compare as-is
+	return normalizedPath1 === normalizedPath2;
 }

--- a/src/tasks/CamelExportJBangTask.ts
+++ b/src/tasks/CamelExportJBangTask.ts
@@ -22,9 +22,9 @@ import { CamelJBang } from "../requirements/CamelJBang";
 
 export class CamelExportJBangTask extends CamelJBangTask {
 
-	constructor(scope: WorkspaceFolder | TaskScope.Workspace, gav: string, runtime: string) {
+	constructor(scope: WorkspaceFolder | TaskScope.Workspace, gav: string, runtime: string, outputPath: string) {
 		super(scope,
 			'Create a Camel project',
-			new CamelJBang().createProject(gav, runtime));
+			new CamelJBang().createProject(gav, runtime, outputPath));
 	}
 }

--- a/src/ui-test/tests/commands.projects.test.ts
+++ b/src/ui-test/tests/commands.projects.test.ts
@@ -26,16 +26,16 @@ import {
 	WebDriver,
 	Workbench
 } from 'vscode-extension-tester';
+import * as pjson from '../../../package.json';
 import {
 	CREATE_COMMAND_QUARKUS_ID,
 	CREATE_COMMAND_SPRINGBOOT_ID,
 	killTerminal,
 	SPECIFIC_WORKSPACE_NAME,
 	SPECIFIC_WORKSPACE_PATH,
-	waitUntilFileAvailable,
-	waitUntilExtensionIsActivated
+	waitUntilExtensionIsActivated,
+	waitUntilFileAvailable
 } from '../utils/testUtils';
-import * as pjson from '../../../package.json';
 
 describe('Create a Camel Project using command', function () {
 	this.timeout(400000);
@@ -71,12 +71,13 @@ describe('Create a Camel Project using command', function () {
 			it(`Create project`, async function () {
 				await new Workbench().executeCommand(command);
 
-				await driver.wait(async function () {
-					input = await InputBox.create();
-					return input;
-				}, 30000);
+				input = await InputBox.create(30000);
 				await input.setText('com.demo:test:1.0-SNAPSHOT');
 				await input.confirm();
+
+				input = await InputBox.create(30000);
+				await input.confirm();
+				await driver.sleep(1000);
 
 				await waitUntilFileAvailable(driver, 'pom.xml', SPECIFIC_WORKSPACE_NAME, 60000);
 			});


### PR DESCRIPTION
- Removes "enablement" for the project creation commands because we will be always choosing a folder work with.
- Project creation commands do not depend on the workspace root anymore and can be used without one.
- Refactor existing tests to use the additional folder selection dialog.
- Opens a new VSCode instance in the newly created project's folder.