### PR TITLE
FUSETOOLS2-2508 - Do not register the Camel Language Server for package.json file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## 1.8.0
 
 - Provide folder selection when using `Create Camel Quarkus/SpringBoot Project` command
+- Avoid being notified for package.json opening and close as no support is provided for it and every 2 minutes there is a notification for these files
 
 ## 1.7.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@
 import { TelemetryEvent, TelemetryService } from '@redhat-developer/vscode-redhat-telemetry';
 import * as path from 'path';
 import { ExtensionContext, StatusBarAlignment, StatusBarItem, TextEditor, Uri, commands, languages, window, workspace } from 'vscode';
-import { DidChangeConfigurationNotification, LanguageClientOptions } from 'vscode-languageclient';
+import { DidChangeConfigurationNotification, DocumentFilter, LanguageClientOptions } from 'vscode-languageclient';
 import { Executable, LanguageClient } from 'vscode-languageclient/node';
 import * as telemetry from './Telemetry';
 import { NewCamelFileCommand } from './commands/NewCamelFileCommand';
@@ -40,7 +40,21 @@ const SETTINGS_TOP_LEVEL_KEY_CAMEL = 'camel';
 
 let languageClient: LanguageClient;
 
-const SUPPORTED_LANGUAGE_IDS = ['xml', 'java', 'groovy', 'kotlin', 'javascript', 'properties', 'quarkus-properties', 'spring-boot-properties', 'yaml', 'json', 'jsonc'];
+const DOCUMENT_SELECTORS :DocumentFilter[] = [
+	{ language: 'xml' },
+	{ language: 'java' },
+	{ language: 'groovy' },
+	{ language: 'kotlin' },
+	{ language: 'javascript' },
+	{ language: 'properties' },
+	{ language: 'quarkus-properties' },
+	{ language: 'spring-boot-properties' },
+	{ language: 'yaml' },
+	{ language: 'json', pattern: '**/.vscode/*.json' },
+	{ language: 'jsonc', pattern: '**/.vscode/*.json' },
+];
+const SUPPORTED_LANGUAGE_IDS = DOCUMENT_SELECTORS.flatMap(docSel => docSel.language);
+
 export async function activate(context: ExtensionContext) {
 	// Let's enable Javadoc symbols autocompletion, shamelessly copied from MIT licensed code at
 	// https://github.com/Microsoft/vscode/blob/9d611d4dfd5a4a101b5201b8c9e21af97f06e7a7/extensions/typescript/src/typescriptMain.ts#L186
@@ -61,7 +75,7 @@ export async function activate(context: ExtensionContext) {
 
 	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {
-		documentSelector: SUPPORTED_LANGUAGE_IDS,
+		documentSelector: DOCUMENT_SELECTORS,
 		synchronize: {
 			configurationSection: ['camel', 'xml', 'java', 'groovy', 'kotlin', 'javascript', 'properties', 'quarkus-properties', 'spring-boot-properties', 'yaml', 'jsonc'],
 			// Notify the server about file changes to .xml files contain in the workspace


### PR DESCRIPTION
every two minutes, there are events didOpen and didClose for package.json files (not found the reason).
It is polluting Camel logs. Potentially leading to killing the server. Given that the Camel Language server does not provide anything for package.json files, the workaround consists in providing a more strict document selector to discard package.json. As json file, we provide completion only in VS Code launch.json and tasks.json files.

