### PR TITLE
chore: add launch configurations to debug ui-tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,23 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
 			"name": "Launch Camel LSP client Extension",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--debug" ],
-			"stopOnEntry": false,
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}",
+				"--debug"
+			],
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+			"outFiles": [
+				"${workspaceRoot}/out/src/**/*.js"
+			],
 			"preLaunchTask": "compile",
 			"env": {
-				"VSCODE_REDHAT_TELEMETRY_DEBUG":"true"
+				"VSCODE_REDHAT_TELEMETRY_DEBUG": "true"
 			}
 		},
 		{
@@ -24,10 +28,46 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceRoot}",
 				"--extensionTestsPath=${workspaceRoot}/out/src/test/suite/index",
-				"${workspaceRoot}/test Fixture with speci@l chars" ],
-			"stopOnEntry": false,
+				"${workspaceRoot}/test Fixture with speci@l chars"
+			],
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/src/test/**/*.js"]
+			"outFiles": [
+				"${workspaceRoot}/out/src/test/**/*.js"
+			]
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Camel Language Server UI Tests",
+			"preLaunchTask": "compile",
+			"program": "${workspaceFolder}/out/src/ui-test/uitest_runner.js",
+			"sourceMaps": true,
+			"cwd": "${workspaceFolder}",
+			"runtimeArgs": [
+				"--nolazy",
+				"--inspect"
+			],
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"autoAttachChildProcesses": true,
+			"env": {
+				"CODE_VERSION": "max"
+			}
+		},
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Node Process",
+			"port": 9229,
+			"restart": true,
+			"timeout": 10000,
+			"sourceMaps": true,
+			"cwd": "${workspaceFolder}",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"autoAttachChildProcesses": true
 		}
 	]
 }

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -21,6 +21,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { ExTester, ReleaseQuality } from 'vscode-extension-tester';
 
+process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled Rejection:', reason);
+});
+
 // Enforce same default storage setup as ExTester - see https://github.com/redhat-developer/vscode-extension-tester/wiki/Test-Setup#useful-env-variables
 export const storageFolder = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : `${os.tmpdir()}/test-resources`;
 const releaseType: ReleaseQuality = process.env.CODE_TYPE === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,19 @@
 {
 	"compilerOptions": {
-		"module": "Node16",		
+		"module": "Node16",
 		"moduleResolution": "Node16",
 		"target": "ES2022",
 		"lib": [
-            "ES2022"
-        ],
+			"ES2022"
+		],
 		"outDir": "out",
 		"resolveJsonModule": true,
 		"strict": true,
 		"forceConsistentCasingInFileNames": true,
-		"skipLibCheck": true // don't know how to fix it
+		"skipLibCheck": true, // don't know how to fix it
+		"sourceMap": true,
+		"inlineSources": true,
+		"rootDir": "."
 	},
 	"include": [
 		"src"


### PR DESCRIPTION
  - Adds launch configuration to start ui-tests.
  - Adds launch configuration to attach to a running node process
    (usefull when launching from the terminal with VSCode's auto attach
    feature enabled).
  - Adds better handling of exceptions in the ui-test runner. The
    runner will print the exception message and stack trace to the
    console.