### PR TITLE
Use MacOS 13 on GitHub CI

### DIFF
--- a/.github/workflows/camel_version.yaml
+++ b/.github/workflows/camel_version.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         camel-version: [ "4.4.0",  "4.0.0.redhat-00036", "4.4.0.redhat-00046"]
 
     env:
@@ -42,7 +42,7 @@ jobs:
         run: java --version
 
       - name: Install JBang (ubuntu, macOS)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-latest'
+        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-13'
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH

--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ "17" ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         version: [ latest ] # [ x.x.x | latest | max ]
         type: [ insider ] # [ stable | insider ]
       fail-fast: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
   main:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         version: [ "1.90.2", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
         run: java --version
 
       - name: Install JBang (ubuntu, macOS)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-latest'
+        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-13'
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH


### PR DESCRIPTION
workaround as some tests started to fail on CI

reported https://issues.redhat.com/browse/FUSETOOLS2-2538 to switch it back to latest

it allows to unblock work on the other PRs

