### PR TITLE
FUSETOOLS2-2554 - Allow hyphen in Artifact Ids when exporting to a Camel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 1.11.0
 
+- Allow hyphen in artifact id when exporting to a Camel Quarkus or Spring Boot project
+
 ## 1.10.0
 
 - Update default Camel version used for Camel JBang from 4.9.0 to 4.10.2

--- a/src/commands/AbstractNewCamelProjectCommand.ts
+++ b/src/commands/AbstractNewCamelProjectCommand.ts
@@ -102,23 +102,23 @@ export abstract class AbstractNewCamelProjectCommand {
 		if (groupIdSplit[0].length === 0) {
 			return 'The group id cannot start with a .';
 		}
-		for (const groupidSubPart of groupIdSplit) {
-			const regExpSearch = /^[a-z]\w*$/.exec(groupidSubPart);
+		for (const groupIdSubPart of groupIdSplit) {
+			const regExpSearch = /^(?!\.)[a-z0-9]+(\.[a-z0-9]+)*$/.exec(groupIdSubPart);
 			if (regExpSearch === null || regExpSearch.length === 0) {
-				return `Invalid subpart of group Id: ${groupidSubPart}} . It must follow groupId:artifactId:version pattern with group Id subpart separated by dot needs to follow this specific pattern: [a-zA-Z]\\w*`;
+				return `Invalid subpart of groupId: '${groupIdSubPart}'. The groupId is expected to follow the Java package naming conventions.`;
 			}
 		}
 
 		const artifactId = gavs[1];
-		const regExpSearchArtifactId = /^[a-zA-Z]\w*$/.exec(artifactId);
+		const regExpSearchArtifactId = /^(?!-)[a-z0-9]+(-[a-z0-9]+)*$/.exec(artifactId);
 		if (regExpSearchArtifactId === null || regExpSearchArtifactId.length === 0) {
-			return `Invalid artifact Id: ${artifactId}} . It must follow groupId:artifactId:version pattern with artifactId specific pattern: [a-zA-Z]\\w*`;
+			return `Invalid artifactId: '${artifactId}'. The identifiers should only consist of lowercase letters, digits, and hyphens.`;
 		}
 
 		const version = gavs[2];
-		const regExpSearch = /^\d[\w-.]*$/.exec(version);
+		const regExpSearch = /^(\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+(-\d+)?)?(\+[A-Za-z0-9]+)?)$/.exec(version);
 		if (regExpSearch === null || regExpSearch.length === 0) {
-			return `Invalid version: ${version} . It must follow groupId:artifactId:version pattern with version specific pattern: \\d[\\w-.]*`;
+			return `Invalid version: '${version}'. The version is expected be compliant with Semantic Versioning 1.0.0.`;
 		}
 		return undefined;
 	}

--- a/src/test/suite/camel.project.command.test.ts
+++ b/src/test/suite/camel.project.command.test.ts
@@ -32,7 +32,8 @@ describe('Should validate Create a Camel Project command', function () {
 				expect(command.validateGAV('com.test:demo:1.0-SNAPSHOT')).to.be.undefined;
 				expect(command.validateGAV('com:demo:1.0-SNAPSHOT')).to.be.undefined;
 				expect(command.validateGAV('com.test:demo:1.0')).to.be.undefined;
-				expect(command.validateGAV('com.test:Demo:1.0')).to.be.undefined;
+				expect(command.validateGAV('com.test:demo-with-hyphen:1.0')).to.be.undefined;
+				expect(command.validateGAV('com.test:demo:1.0+df0')).to.be.undefined;
 			});
 
 			it('Validate not empty', function () {
@@ -51,11 +52,14 @@ describe('Should validate Create a Camel Project command', function () {
 				expect(command.validateGAV('invalid:invalid:1.0- with space')).to.not.be.undefined;
 			});
 
-			it('Validate contains valid characters', function () {
+			it('Validate contains invalid characters', function () {
 				expect(command.validateGAV('.invalid:valid:1.0-SNAPSHOT')).to.not.be.undefined;
 				expect(command.validateGAV('%invalid:valid:1.0-SNAPSHOT')).to.not.be.undefined;
 				expect(command.validateGAV('va.lid:%invalid:1.0-SNAPSHOT')).to.not.be.undefined;
 				expect(command.validateGAV('va.lid:valid:1.0-%invalid')).to.not.be.undefined;
+				expect(command.validateGAV('valid:Invalid:1.0-%invalid')).to.not.be.undefined;
+				expect(command.validateGAV('valid:Invalid:1.0')).to.not.be.undefined;
+				expect(command.validateGAV('valid:in_valid:1.0')).to.not.be.undefined;
 			});
 		});
 	});


### PR DESCRIPTION
Quarkus or Spring Boot project

based on https://github.com/KaotoIO/vscode-kaoto/pull/826/files