### PR TITLE
FUSETOOLS2-2540 - avoid flakiness in tests due to file cannot be saved

### DIFF
--- a/src/ui-test/tests/14_properties.test.ts
+++ b/src/ui-test/tests/14_properties.test.ts
@@ -62,7 +62,7 @@ describe('Camel properties auto-completion support', function () {
 	});
 
 	after(async function () {
-		await closeEditor(TEST_FILE, true);
+		await closeEditor(TEST_FILE, false);
 		await deleteFile(TEST_FILE, RESOURCES);
 	});
 


### PR DESCRIPTION
it was resulting to next test to not be able to activate the extension. this test doesn't need to save the file when closing the editor as the file is deleted right after. Note that I have not found why when trying to save there was an error stating that the file does not exist.

