### PR TITLE
FUSETOOLS2-2566 - increase timeout to create kamelet file in subfolders

### DIFF
--- a/src/test/suite/camel.kamelet.command.test.ts
+++ b/src/test/suite/camel.kamelet.command.test.ts
@@ -65,7 +65,7 @@ describe('Should execute Create a Kamelet command', function () {
 				const workspaceFolder :vscode.WorkspaceFolder = vscode.workspace.workspaceFolders![0];
 				await initNewFile(fileName, param.type, vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, 'a sub folder')));
 
-				const createdFile = await waitUntilFileIsCreated(fullFileName);
+				const createdFile = await waitUntilFileIsCreated(fullFileName, 10_000);
 				expect(createdFile.fsPath).not.to.be.undefined;
 
 				const openedEditor = await waitUntilEditorIsOpened(fullFileName);


### PR DESCRIPTION
in test

on Windows on Ci, it regularly failed with timeout of 5 seconds. Fo rinstance, on another windows run, it pwas succesful  but the whole test took 4s https://github.com/camel-tooling/camel-lsp-client-vscode/actions/runs/13964203526/job/39090907722?pr=2140#step:14:96

