### PR TITLE
fix: prevent uitest_runner.js to be executed either when only some specific test is called

### DIFF
--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -52,6 +52,8 @@ async function main(): Promise<void> {
 	fs.rmSync(extensionFolder, { recursive: true });
 }
 
-main().catch((error) => {
-	throw Error('Unhandled promise rejection in main(): ', error);
-});
+if (require.main === module) {
+	main().catch((error) => {
+		throw Error('Unhandled promise rejection in main(): ', error);
+	});
+}


### PR DESCRIPTION
I have noticed that the all UI tests are executed all the time even if I call only one specific file to be run

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build
