### PR TITLE
changelog Fix: provide completion for api properties on method which

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Provide a VS Code task `Deploy on OpenShift` when creating a Camel Quarkus project
 - Attribute name completion now have group, requirement and default value with new line respected
+- Fix: provide completion for api properties on method which doesn't have an alias for API-based component
 - Update default Camel Catalog version from 4.12.0 to 4.13.0
 - Update Camel Quarkus Catalog from 3.23.0 to 3.24.0
 - Update default Camel version used for Camel JBang from 4.12.0 to 4.13.0


### PR DESCRIPTION
doesn't have an alias for API-based component

requires https://github.com/camel-tooling/camel-language-server/pull/1309