### PR TITLE
Using conditional wait for editor to appear

### DIFF
--- a/src/ui-test/tests/05_camel.settings.test.ts
+++ b/src/ui-test/tests/05_camel.settings.test.ts
@@ -52,6 +52,7 @@ import {
 	WebDriver
 } from 'vscode-extension-tester';
 import * as pjson from '../../../package.json';
+import waitUntil from 'async-wait-until';
 
 describe('User preferences', function () {
 
@@ -141,10 +142,17 @@ describe('User preferences', function () {
 		it('Default version', async function () {
 			// open file
 			await VSBrowser.instance.openResources(path.join(RESOURCES, CAMEL_CONTEXT_XML));
+			await waitUntil(async () => {
+				try {
+					const editor = new TextEditor();
+					return await editor.isDisplayed();
+				} catch {
+					return false;
+				}
+			});
 
 			// add component
 			const editor = new TextEditor();
-			await editor.isDisplayed();
 			await editor.typeTextAt(3, XML_URI_POSITION, 'knative');
 
 			// open ca


### PR DESCRIPTION
to avoid this flaky error:
```
1) User preferences
       Camel Catalog version
         Default version:
     NoSuchElementError: no such element: Unable to locate element:
{"method":"css selector","selector":".editor-instance"}
  (Session info: chrome=122.0.6261.156)
      at Object.throwDecodedError
(node_modules/selenium-webdriver/lib/error.js:523:15)
      at parseHttpResponse
(node_modules/selenium-webdriver/lib/http.js:524:13)
      at Executor.execute
(node_modules/selenium-webdriver/lib/http.js:456:28)
      at process.processTicksAndRejections
(node:internal/process/task_queues:95:5)
      at async Driver.execute
(node_modules/selenium-webdriver/lib/webdriver.js:745:17)
      at async toWireValue
(node_modules/selenium-webdriver/lib/webdriver.js:149:15)
      at async /Users/runner/work/camel-lsp-client-vscode/camel-lsp-client-vscode/node_modules/selenium-webdriver/lib/webdriver.js:195:16
      at async forEachKey
(node_modules/selenium-webdriver/lib/webdriver.js:189:9)
      at async convertKeys
(node_modules/selenium-webdriver/lib/webdriver.js:194:3)
      at async Driver.execute
(node_modules/selenium-webdriver/lib/webdriver.js:743:22)
      at async Context.<anonymous>
(out/src/ui-test/tests/05_camel.settings.test.js:119:13)
```

