### PR TITLE
Use MacOS 15 on CI

### DIFF
--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ "17" ]
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-15-intel, windows-latest ]
         version: [ latest ] # [ x.x.x | latest | max ]
         type: [ insider ] # [ stable | insider ]
       fail-fast: false
@@ -98,7 +98,7 @@ jobs:
 
       - name: Store VS Code Logs (Macos)
         uses: actions/upload-artifact@v4
-        if: failure() && matrix.os == 'macos-13'
+        if: failure() && matrix.os == 'macos-15-intel'
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-vscode-logs
           path: ~/Library/Application Support/Code/logs/*

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
   main:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-15-intel, windows-latest ]
         version: [ "1.90.2", max ] # [ "x.x.x" | latest | max ]
         type: [ stable ] # [ stable | insider ]
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
         run: java --version
 
       - name: Install JBang (ubuntu, macOS)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-13'
+        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-15-intel'
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH


### PR DESCRIPTION
using the x86_64 (intel) architecture as with the arm based some tests to create project are always failing (but they are known to be flaky currently, just so far failed 100% time with arm). x86_64 GitHub macos runners are planned to be retired in 2027

fixes #2303

