### PR TITLE
ci: cache VS Code test downloads and add prewarm workflow

### DIFF
--- a/.github/workflows/camel_version.yaml
+++ b/.github/workflows/camel_version.yaml
@@ -68,6 +68,22 @@ jobs:
       - name: npm-ci
         run: npm ci
 
+      - name: Restore VS Code test cache
+        id: vscode-test-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
+          restore-keys: |
+            vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}-
+
       - name: Allow unprivileged user namespace (ubuntu)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
@@ -77,6 +93,20 @@ jobs:
 
       - name: vsce-package
         run: vsce package
+
+      - name: Save VS Code test cache
+        if: always() && steps.vscode-test-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
 
       - name: Store Camel Language Server log
         uses: actions/upload-artifact@v7

--- a/.github/workflows/insider.yaml
+++ b/.github/workflows/insider.yaml
@@ -54,6 +54,22 @@ jobs:
       - name: npm-ci
         run: npm ci
 
+      - name: Restore VS Code test cache
+        id: vscode-test-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
+          restore-keys: |
+            vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}-
+
       - name: npm-vscode:prepublish
         run: npm run vscode:prepublish
 
@@ -81,6 +97,20 @@ jobs:
       #   id: uiTest_MacOS_Windows
       #   if: ${{ !startsWith(matrix.os, 'ubuntu') }}
       #   run: npm run ui-test
+
+      - name: Save VS Code test cache
+        if: always() && steps.vscode-test-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
 
       - name: Store Camel Language Server log
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,6 +68,22 @@ jobs:
       - name: npm-ci
         run: npm ci
 
+      - name: Restore VS Code test cache
+        id: vscode-test-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
+          restore-keys: |
+            vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}-
+
       - name: npm-vscode:prepublish
         run: npm run vscode:prepublish
 
@@ -96,6 +112,20 @@ jobs:
 
       - name: vsce-package
         run: vsce package
+
+      - name: Save VS Code test cache
+        if: always() && steps.vscode-test-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
 
       - name: get-npm-version
         id: package-version

--- a/.github/workflows/vscode_cache_prewarm.yaml
+++ b/.github/workflows/vscode_cache_prewarm.yaml
@@ -1,0 +1,93 @@
+name: VS Code Download Cache Prewarm
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prewarm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            version: max
+            type: stable
+          - os: macos-15-intel
+            version: max
+            type: stable
+          - os: windows-latest
+            version: max
+            type: stable
+          - os: ubuntu-latest
+            version: latest
+            type: insider
+          - os: macos-15-intel
+            version: latest
+            type: insider
+          - os: windows-latest
+            version: latest
+            type: insider
+
+    env:
+      CODE_VERSION: ${{ matrix.version }}
+      CODE_TYPE: ${{ matrix.type }}
+      TEST_RESOURCES: test-resources
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}-${{ matrix.type }}-${{ matrix.version }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Restore VS Code test cache
+        id: vscode-test-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}
+          restore-keys: |
+            vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prewarm VS Code downloads
+        run: node ./scripts/prewarm-vscode-downloads.js
+
+      - name: Save VS Code test cache
+        if: always() && steps.vscode-test-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .vscode-test/vscode-*
+            .vscode-test/extensions
+            test-resources/Visual Studio Code.app
+            test-resources/Visual Studio Code - Insiders.app
+            test-resources/VSCode-*
+            test-resources/chromedriver*
+            test-resources/driverVersion
+          key: vscode-test-cache-v2-${{ runner.os }}-${{ runner.arch }}-${{ env.CODE_TYPE }}-${{ env.CODE_VERSION }}

--- a/scripts/prewarm-vscode-downloads.js
+++ b/scripts/prewarm-vscode-downloads.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { downloadAndUnzipVSCode } = require('@vscode/test-electron');
+const { ExTester, ReleaseQuality } = require('vscode-extension-tester');
+
+function resolveStorageFolder() {
+	return process.env.TEST_RESOURCES ? path.resolve(process.env.TEST_RESOURCES) : path.join(os.tmpdir(), 'test-resources');
+}
+
+function resolveTestElectronVersion() {
+	const version = process.env.CODE_VERSION;
+
+	if (version === undefined || version === 'max') {
+		return 'stable';
+	} else if (version === 'latest') {
+		return 'insiders';
+	}
+	return version;
+}
+
+function resolveReleaseType() {
+	return process.env.CODE_TYPE === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;
+}
+
+function clearCacheEntries(folder, matcher) {
+	if (!fs.existsSync(folder)) {
+		return;
+	}
+
+	for (const entry of fs.readdirSync(folder)) {
+		if (matcher(entry)) {
+			fs.rmSync(path.join(folder, entry), { recursive: true, force: true });
+		}
+	}
+}
+
+function clearTestElectronCache() {
+	clearCacheEntries(path.resolve('.vscode-test'), (entry) => entry.startsWith('vscode-'));
+}
+
+function clearExTesterCache(storageFolder) {
+	clearCacheEntries(storageFolder, (entry) => {
+		return entry === 'Visual Studio Code.app'
+			|| entry === 'Visual Studio Code - Insiders.app'
+			|| entry === 'driverVersion'
+			|| entry.startsWith('VSCode-')
+			|| entry.startsWith('chromedriver')
+			|| entry.endsWith('.zip')
+			|| entry.endsWith('.tar.gz');
+	});
+}
+
+async function retryWithFreshCache(label, clearCache, action) {
+	try {
+		await action();
+	} catch (error) {
+		console.warn(`${label} cache recovery triggered`, error);
+		clearCache();
+		await action();
+	}
+}
+
+async function main() {
+	const storageFolder = resolveStorageFolder();
+	const codeVersion = process.env.CODE_VERSION ?? 'max';
+
+	console.log(`Prewarming @vscode/test-electron cache for ${resolveTestElectronVersion()}`);
+	await retryWithFreshCache('@vscode/test-electron', clearTestElectronCache, async () => {
+		await downloadAndUnzipVSCode({
+			version: resolveTestElectronVersion(),
+			cachePath: path.resolve('.vscode-test')
+		});
+	});
+
+	console.log(`Prewarming vscode-extension-tester cache for ${codeVersion} / ${process.env.CODE_TYPE ?? 'stable'}`);
+	const tester = new ExTester(storageFolder, resolveReleaseType());
+	await retryWithFreshCache('vscode-extension-tester', () => clearExTesterCache(storageFolder), async () => {
+		await tester.downloadCode(codeVersion);
+		await tester.downloadChromeDriver(codeVersion);
+	});
+}
+
+main().catch((error) => {
+	console.error('Failed to prewarm VS Code download cache', error);
+	process.exit(1);
+});


### PR DESCRIPTION
ci: cache VS Code test downloads and add prewarm workflow

Reuse downloaded VS Code test runtimes across CI jobs and prewarm them
on main so PR workflows are less likely to hit VS Code download rate limits.

- restore/save shared caches for @vscode/test-electron and ExTester assets
- add a dedicated cache prewarm workflow for stable and insider matrices
- prewarm both VS Code and ChromeDriver downloads before test workflows need them
- recover from corrupted local cache entries by clearing and retrying once
- cache unpacked runtimes instead of raw downloaded archives
